### PR TITLE
feat: implement local database mock for E2E testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,25 @@ jobs:
       - name: Knip
         run: pnpm knip
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
   build:
     runs-on: ubuntu-latest
     needs: lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Prerequisites:
 
 ### Integration Tests
 
-Integration tests verify service layer logic using the in-memory database mock. They can run in CI.
+Integration tests verify service layer logic using the in-memory fake database. They can run in CI.
 
 ```bash
 pnpm test
@@ -58,4 +58,4 @@ Test files: `src/services/**/*.test.ts`
 
 ### Database Mock
 
-Both E2E and integration tests use the in-memory database (`TARO_APP_ENV=test`) to avoid polluting production data. The mock supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.
+Both E2E and integration tests use the in-memory fake database (`TARO_APP_ENV=test`) to avoid polluting production data. The fake database supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ After creating or updating a PR:
 
 ### E2E Tests
 
-E2E tests use `miniprogram-automator` to test the full mini program in WeChat DevTools. They require local environment and cannot run in CI.
+E2E tests use `miniprogram-automator` to test the full mini program in WeChat DevTools with **real cloud database**. They require local environment and cannot run in CI.
 
 Run locally after pushing:
 
@@ -46,9 +46,11 @@ Prerequisites:
 - WeChat DevTools installed with Service Port enabled (Settings > Security)
 - `.env.local` configured with valid appID and cloud environment
 
+Data isolation: E2E tests use a fixed test user ID (`e2e_test_user`) to avoid polluting real user data.
+
 ### Integration Tests
 
-Integration tests verify service layer logic using the in-memory fake database. They can run in CI.
+Integration tests verify service layer logic using the in-memory fake database. They run in CI.
 
 ```bash
 pnpm test
@@ -58,14 +60,15 @@ Test files: `src/services/**/*.test.ts`
 
 ### Fake Database
 
-Both E2E and integration tests use the in-memory fake database to avoid polluting production data. The fake database supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.
+Integration tests use the in-memory fake database (`TARO_APP_ENV=test`). The fake database supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.
 
 ## Build-time Constants
 
 Use `defineConstants` in `config/index.ts` for environment-specific values. Do not use `process.env` directly in source code — it doesn't exist at runtime in mini programs.
 
 Current constants:
-- `IS_TEST_ENV`: `true` when building with `TARO_APP_ENV=test`, otherwise `false`
+- `IS_TEST_ENV`: `true` when building with `TARO_APP_ENV=test` (integration tests, fake database)
+- `IS_E2E_ENV`: `true` when building with `TARO_APP_ENV=e2e` (E2E tests, real database + test user)
 
 To add a new constant:
 1. Define in `config/index.ts` under `defineConstants`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,13 @@ After creating or updating a PR:
 2. Run E2E tests locally (can run in parallel with CI)
 3. Monitor CI status. If CI fails, investigate and fix promptly.
 
-## E2E Testing
+## Testing Strategy
 
-E2E tests require WeChat DevTools and cannot run in CI. Run locally after pushing:
+### E2E Tests
+
+E2E tests use `miniprogram-automator` to test the full mini program in WeChat DevTools. They require local environment and cannot run in CI.
+
+Run locally after pushing:
 
 ```bash
 pnpm test:e2e
@@ -41,3 +45,17 @@ pnpm test:e2e
 Prerequisites:
 - WeChat DevTools installed with Service Port enabled (Settings > Security)
 - `.env.local` configured with valid appID and cloud environment
+
+### Integration Tests
+
+Integration tests verify service layer logic using the in-memory database mock. They can run in CI.
+
+```bash
+pnpm test
+```
+
+Test files: `src/services/**/*.test.ts`
+
+### Database Mock
+
+Both E2E and integration tests use the in-memory database (`TARO_APP_ENV=test`) to avoid polluting production data. The mock supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,17 @@ pnpm test
 
 Test files: `src/services/**/*.test.ts`
 
-### Database Mock
+### Fake Database
 
-Both E2E and integration tests use the in-memory fake database (`TARO_APP_ENV=test`) to avoid polluting production data. The fake database supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.
+Both E2E and integration tests use the in-memory fake database to avoid polluting production data. The fake database supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.
+
+## Build-time Constants
+
+Use `defineConstants` in `config/index.ts` for environment-specific values. Do not use `process.env` directly in source code — it doesn't exist at runtime in mini programs.
+
+Current constants:
+- `IS_TEST_ENV`: `true` when building with `TARO_APP_ENV=test`, otherwise `false`
+
+To add a new constant:
+1. Define in `config/index.ts` under `defineConstants`
+2. Declare type in the source file: `declare const MY_CONSTANT: string;`

--- a/config/index.ts
+++ b/config/index.ts
@@ -21,7 +21,7 @@ export default defineConfig<'vite'>(async (merge, { command, mode }) => {
       "@tarojs/plugin-generator"
     ],
     defineConstants: {
-      'process.env.TARO_APP_ENV': JSON.stringify(process.env.TARO_APP_ENV || ''),
+      IS_TEST_ENV: JSON.stringify(process.env.TARO_APP_ENV === 'test'),
     },
     copy: {
       patterns: [

--- a/config/index.ts
+++ b/config/index.ts
@@ -22,6 +22,7 @@ export default defineConfig<'vite'>(async (merge, { command, mode }) => {
     ],
     defineConstants: {
       IS_TEST_ENV: JSON.stringify(process.env.TARO_APP_ENV === 'test'),
+      IS_E2E_ENV: JSON.stringify(process.env.TARO_APP_ENV === 'e2e'),
     },
     copy: {
       patterns: [

--- a/config/index.ts
+++ b/config/index.ts
@@ -21,6 +21,7 @@ export default defineConfig<'vite'>(async (merge, { command, mode }) => {
       "@tarojs/plugin-generator"
     ],
     defineConstants: {
+      'process.env.TARO_APP_ENV': JSON.stringify(process.env.TARO_APP_ENV || ''),
     },
     copy: {
       patterns: [

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "prepare": "lefthook install",
     "postinstall": "lefthook install",
     "build": "taro build --type weapp",
+    "build:test": "TARO_APP_ENV=test taro build --type weapp",
     "dev": "taro build --type weapp --watch",
     "lint": "oxlint src",
     "knip": "knip",
     "format": "oxfmt src --write",
     "format:check": "oxfmt src",
-    "test:e2e": "pnpm build && vitest run --config e2e/vitest.config.ts"
+    "test:e2e": "pnpm build:test && vitest run --config e2e/vitest.config.ts"
   },
   "dependencies": {
     "@babel/runtime": "^7.24.4",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "postinstall": "lefthook install",
     "build": "taro build --type weapp",
     "build:test": "TARO_APP_ENV=test taro build --type weapp",
+    "build:e2e": "TARO_APP_ENV=e2e taro build --type weapp",
     "dev": "taro build --type weapp --watch",
     "lint": "oxlint src",
     "knip": "knip",
     "format": "oxfmt src --write",
     "format:check": "oxfmt src",
     "test": "vitest run",
-    "test:e2e": "pnpm build:test && vitest run --config e2e/vitest.config.ts"
+    "test:e2e": "pnpm build:e2e && vitest run --config e2e/vitest.config.ts"
   },
   "dependencies": {
     "@babel/runtime": "^7.24.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "knip": "knip",
     "format": "oxfmt src --write",
     "format:check": "oxfmt src",
+    "test": "vitest run",
     "test:e2e": "pnpm build:test && vitest run --config e2e/vitest.config.ts"
   },
   "dependencies": {

--- a/src/services/health.test.ts
+++ b/src/services/health.test.ts
@@ -25,7 +25,7 @@ describe('health service', () => {
       });
 
       expect(id).toBeDefined();
-      expect(id).toMatch(/^mock_/);
+      expect(id).toMatch(/^fake_/);
     });
 
     it('should add record with note', async () => {

--- a/src/services/health.test.ts
+++ b/src/services/health.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { addHealthRecord, getRecentHealthRecords, deleteHealthRecord } from './health';
+
+// Mock getOpenId to return a test user
+vi.mock('../utils/cloud', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../utils/cloud')>();
+  return {
+    ...original,
+    getOpenId: vi.fn().mockResolvedValue('test_user_001'),
+  };
+});
+
+describe('health service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('addHealthRecord', () => {
+    it('should add a health record and return id', async () => {
+      const id = await addHealthRecord({
+        date: '2026-04-11',
+        time: '10:00',
+        symptoms: [{ type: 'bloating', severity: 2 }],
+        overallFeeling: 3,
+      });
+
+      expect(id).toBeDefined();
+      expect(id).toMatch(/^mock_/);
+    });
+
+    it('should add record with note', async () => {
+      const id = await addHealthRecord({
+        date: '2026-04-11',
+        symptoms: [],
+        overallFeeling: 4,
+        note: 'Feeling better today',
+      });
+
+      expect(id).toBeDefined();
+    });
+  });
+
+  describe('getRecentHealthRecords', () => {
+    it('should return empty array when no records', async () => {
+      const records = await getRecentHealthRecords(10);
+      // May have records from previous tests due to shared memory db
+      expect(Array.isArray(records)).toBe(true);
+    });
+
+    it('should return records for current user', async () => {
+      // Add a record first
+      await addHealthRecord({
+        date: '2026-04-11',
+        symptoms: [],
+        overallFeeling: 3,
+      });
+
+      const records = await getRecentHealthRecords(10);
+      expect(records.length).toBeGreaterThan(0);
+      expect(records[0].userId).toBe('test_user_001');
+    });
+
+    it('should respect limit parameter', async () => {
+      // Add multiple records
+      for (let i = 0; i < 5; i++) {
+        await addHealthRecord({
+          date: `2026-04-${10 + i}`,
+          symptoms: [],
+          overallFeeling: 3,
+        });
+      }
+
+      const records = await getRecentHealthRecords(3);
+      expect(records.length).toBeLessThanOrEqual(3);
+    });
+
+    it('should order by createdAt descending', async () => {
+      const records = await getRecentHealthRecords(10);
+
+      if (records.length >= 2) {
+        for (let i = 0; i < records.length - 1; i++) {
+          const current = new Date(records[i].createdAt).getTime();
+          const next = new Date(records[i + 1].createdAt).getTime();
+          expect(current).toBeGreaterThanOrEqual(next);
+        }
+      }
+    });
+  });
+
+  describe('deleteHealthRecord', () => {
+    it('should delete a record', async () => {
+      // Add a record first
+      const id = await addHealthRecord({
+        date: '2026-04-11',
+        symptoms: [],
+        overallFeeling: 5,
+        note: 'To be deleted',
+      });
+
+      // Get count before delete
+      const beforeRecords = await getRecentHealthRecords(100);
+      const countBefore = beforeRecords.length;
+
+      // Delete the record
+      await deleteHealthRecord(id);
+
+      // Verify count decreased
+      const afterRecords = await getRecentHealthRecords(100);
+      expect(afterRecords.length).toBe(countBefore - 1);
+    });
+
+    it('should not throw when deleting non-existent record', async () => {
+      await expect(deleteHealthRecord('non_existent_id')).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest';
+
+// Mock Taro globals required by @tarojs/runtime
+globalThis.ENABLE_INNER_HTML = true;
+globalThis.ENABLE_ADJACENT_HTML = true;
+globalThis.ENABLE_SIZE_APIS = true;
+globalThis.ENABLE_TEMPLATE_CONTENT = true;
+globalThis.ENABLE_CLONE_NODE = true;
+globalThis.ENABLE_CONTAINS = true;
+globalThis.ENABLE_MUTATION_OBSERVER = true;
+
+// Mock Taro module
+vi.mock('@tarojs/taro', () => ({
+  default: {
+    cloud: {
+      database: vi.fn(),
+      callFunction: vi.fn(),
+      init: vi.fn(),
+    },
+    getStorageSync: vi.fn(),
+    setStorageSync: vi.fn(),
+  },
+  cloud: {
+    database: vi.fn(),
+    callFunction: vi.fn(),
+    init: vi.fn(),
+  },
+  getStorageSync: vi.fn(),
+  setStorageSync: vi.fn(),
+}));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,8 @@
 import { vi } from 'vitest';
 
+// Define IS_TEST_ENV for test environment
+(globalThis as unknown as { IS_TEST_ENV: boolean }).IS_TEST_ENV = true;
+
 // Mock Taro globals required by @tarojs/runtime
 globalThis.ENABLE_INNER_HTML = true;
 globalThis.ENABLE_ADJACENT_HTML = true;

--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -61,7 +61,7 @@ function createMemoryCollection(data: Record<string, unknown>[]) {
       return { data: result };
     },
     async add({ data: doc }: { data: Record<string, unknown> }) {
-      const _id = `mock_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      const _id = `fake_${Date.now()}_${Math.random().toString(36).slice(2)}`;
       data.push({ _id, ...doc });
       return { _id };
     },

--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -1,7 +1,110 @@
 import Taro from "@tarojs/taro";
 
+const isTest = process.env.TARO_APP_ENV === "test";
+
+// 内存数据库存储
+const memoryStore: Map<string, Record<string, unknown>[]> = new Map();
+
+// 内存数据库实现
+function createMemoryDatabase() {
+  return {
+    collection(name: string) {
+      if (!memoryStore.has(name)) {
+        memoryStore.set(name, []);
+      }
+      const data = memoryStore.get(name)!;
+      return createMemoryCollection(data);
+    },
+  };
+}
+
+function createMemoryCollection(data: Record<string, unknown>[]) {
+  let filters: Record<string, unknown> = {};
+  let sortField: string | null = null;
+  let sortOrder: "asc" | "desc" = "asc";
+  let limitCount: number | null = null;
+
+  const query = {
+    where(condition: Record<string, unknown>) {
+      filters = { ...filters, ...condition };
+      return query;
+    },
+    orderBy(field: string, order: "asc" | "desc") {
+      sortField = field;
+      sortOrder = order;
+      return query;
+    },
+    limit(count: number) {
+      limitCount = count;
+      return query;
+    },
+    async get() {
+      let result = data.filter((item) => {
+        return Object.entries(filters).every(([key, value]) => item[key] === value);
+      });
+
+      if (sortField) {
+        const field = sortField;
+        result = result.sort((a, b) => {
+          const aVal = a[field];
+          const bVal = b[field];
+          if (aVal < bVal) return sortOrder === "asc" ? -1 : 1;
+          if (aVal > bVal) return sortOrder === "asc" ? 1 : -1;
+          return 0;
+        });
+      }
+
+      if (limitCount !== null) {
+        result = result.slice(0, limitCount);
+      }
+
+      return { data: result };
+    },
+    async add({ data: doc }: { data: Record<string, unknown> }) {
+      const _id = `mock_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      data.push({ _id, ...doc });
+      return { _id };
+    },
+    doc(id: string) {
+      return {
+        async get() {
+          const item = data.find((d) => d._id === id);
+          return { data: item || null };
+        },
+        async remove() {
+          const index = data.findIndex((d) => d._id === id);
+          if (index !== -1) {
+            data.splice(index, 1);
+          }
+        },
+        async update({ data: updates }: { data: Record<string, unknown> }) {
+          const item = data.find((d) => d._id === id);
+          if (item) {
+            Object.assign(item, updates);
+          }
+        },
+      };
+    },
+  };
+
+  return query;
+}
+
+// 内存数据库单例
+let memoryDb: ReturnType<typeof createMemoryDatabase> | null = null;
+
+function getMemoryDatabase() {
+  if (!memoryDb) {
+    memoryDb = createMemoryDatabase();
+  }
+  return memoryDb;
+}
+
 // 获取数据库实例
 export function getDatabase() {
+  if (isTest) {
+    return getMemoryDatabase();
+  }
   return Taro.cloud.database();
 }
 

--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -1,6 +1,9 @@
 import Taro from "@tarojs/taro";
 
 declare const IS_TEST_ENV: boolean;
+declare const IS_E2E_ENV: boolean;
+
+const E2E_TEST_USER_ID = "e2e_test_user";
 
 // 内存数据库存储
 const memoryStore: Map<string, Record<string, unknown>[]> = new Map();
@@ -112,6 +115,11 @@ export function getDatabase() {
 let cachedOpenId: string | null = null;
 
 export async function getOpenId(): Promise<string> {
+  // E2E 测试使用固定的测试用户 ID
+  if (IS_E2E_ENV) {
+    return E2E_TEST_USER_ID;
+  }
+
   if (cachedOpenId) {
     return cachedOpenId;
   }

--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -1,6 +1,6 @@
 import Taro from "@tarojs/taro";
 
-const isTest = process.env.TARO_APP_ENV === "test";
+declare const IS_TEST_ENV: boolean;
 
 // 内存数据库存储
 const memoryStore: Map<string, Record<string, unknown>[]> = new Map();
@@ -102,7 +102,7 @@ function getMemoryDatabase() {
 
 // 获取数据库实例
 export function getDatabase() {
-  if (isTest) {
+  if (IS_TEST_ENV) {
     return getMemoryDatabase();
   }
   return Taro.cloud.database();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+    setupFiles: ['./src/test/setup.ts'],
+    env: {
+      TARO_APP_ENV: 'test',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add in-memory database implementation that replaces cloud database during test builds
- Environment-based switching: `TARO_APP_ENV=test` uses memory database
- Supports operations currently used: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`

## Changes
- `src/utils/cloud.ts`: Add memory database implementation
- `package.json`: Add `build:test` script, update `test:e2e` to use test build

## Test plan
- [ ] Run `pnpm build:test` to verify test build works
- [ ] Run `pnpm test:e2e` to verify E2E tests pass with memory database
- [ ] Verify no console errors about cloud database

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)