### PR TITLE
feat: implement medical record feature (#8)

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -7,6 +7,8 @@ export default defineAppConfig({
     "pages/meal/add/index",
     "pages/stool/index/index",
     "pages/stool/add/index",
+    "pages/medical/index/index",
+    "pages/medical/add/index",
   ],
   window: {
     backgroundTextStyle: "light",

--- a/src/constants/medical.ts
+++ b/src/constants/medical.ts
@@ -1,0 +1,2 @@
+// 最大图片数量
+export const MAX_IMAGES = 9;

--- a/src/pages/medical/add/index.config.ts
+++ b/src/pages/medical/add/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: "添加检查记录",
+});

--- a/src/pages/medical/add/index.css
+++ b/src/pages/medical/add/index.css
@@ -1,0 +1,128 @@
+.add-page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+  padding-bottom: 120px;
+}
+
+.section {
+  background-color: #fff;
+  margin-bottom: 20px;
+  padding: 28px 32px;
+}
+
+.section-title {
+  font-size: 30px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 24px;
+  display: block;
+}
+
+.picker-value {
+  padding: 20px 32px;
+  background-color: #f5f5f5;
+  border-radius: 12px;
+  font-size: 30px;
+  color: #333;
+}
+
+/* 图片网格 */
+.image-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.image-item {
+  position: relative;
+  width: 200px;
+  height: 200px;
+}
+
+.preview-image {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+}
+
+.remove-btn {
+  position: absolute;
+  top: -12px;
+  right: -12px;
+  width: 40px;
+  height: 40px;
+  background-color: #ff4d4f;
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+}
+
+.add-image-btn {
+  width: 200px;
+  height: 200px;
+  background-color: #f5f5f5;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed #ccc;
+}
+
+.add-icon {
+  font-size: 48px;
+  color: #999;
+}
+
+.add-text {
+  font-size: 24px;
+  color: #999;
+  margin-top: 8px;
+}
+
+.image-hint {
+  font-size: 24px;
+  color: #999;
+  margin-top: 16px;
+  display: block;
+}
+
+/* 备注 */
+.note-input {
+  width: 100%;
+  min-height: 160px;
+  padding: 20px;
+  background-color: #f5f5f5;
+  border-radius: 12px;
+  font-size: 28px;
+  line-height: 1.5;
+  box-sizing: border-box;
+}
+
+/* 提交按钮 */
+.submit-section {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 24px 32px;
+  background-color: #fff;
+  box-shadow: 0 -2px 10px rgb(0 0 0 / 5%);
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 28px;
+  background-color: #07c160;
+  color: #fff;
+  font-size: 32px;
+  text-align: center;
+  border-radius: 12px;
+}
+
+.submit-btn.disabled {
+  background-color: #ccc;
+}

--- a/src/pages/medical/add/index.tsx
+++ b/src/pages/medical/add/index.tsx
@@ -1,0 +1,138 @@
+import { View, Text, Image, Textarea, Picker } from "@tarojs/components";
+import Taro from "@tarojs/taro";
+import { useState } from "react";
+import { addMedicalRecord, uploadImages } from "../../../services/medical";
+import { MAX_IMAGES } from "../../../constants/medical";
+import { formatDate } from "../../../utils/date";
+import "./index.css";
+
+export default function MedicalAdd() {
+  const [date, setDate] = useState(formatDate());
+  const [localImages, setLocalImages] = useState<string[]>([]);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleChooseImage = async () => {
+    const remaining = MAX_IMAGES - localImages.length;
+    if (remaining <= 0) {
+      Taro.showToast({ title: `最多上传${MAX_IMAGES}张图片`, icon: "none" });
+      return;
+    }
+
+    try {
+      const res = await Taro.chooseImage({
+        count: remaining,
+        sizeType: ["compressed"],
+        sourceType: ["album", "camera"],
+      });
+      setLocalImages([...localImages, ...res.tempFilePaths]);
+    } catch {
+      // 用户取消选择
+    }
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setLocalImages(localImages.filter((_, i) => i !== index));
+  };
+
+  const handlePreviewImage = (index: number) => {
+    Taro.previewImage({
+      current: localImages[index],
+      urls: localImages,
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+
+    if (localImages.length === 0) {
+      Taro.showToast({ title: "请至少上传一张图片", icon: "none" });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      Taro.showLoading({ title: "上传中..." });
+
+      // 上传图片到云存储
+      const cloudImages = await uploadImages(localImages);
+
+      // 保存记录到数据库
+      await addMedicalRecord({
+        date,
+        images: cloudImages,
+        note: note.trim() || undefined,
+      });
+
+      Taro.hideLoading();
+      Taro.showToast({ title: "保存成功", icon: "success" });
+      setTimeout(() => {
+        Taro.navigateBack();
+      }, 1500);
+    } catch (error) {
+      Taro.hideLoading();
+      console.error("保存失败:", error);
+      Taro.showToast({ title: "保存失败", icon: "none" });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View className="add-page">
+      {/* 日期 */}
+      <View className="section">
+        <Text className="section-title">检查日期</Text>
+        <Picker mode="date" value={date} onChange={(e) => setDate(e.detail.value)}>
+          <View className="picker-value">{date}</View>
+        </Picker>
+      </View>
+
+      {/* 图片上传 */}
+      <View className="section">
+        <Text className="section-title">检查报告图片</Text>
+        <View className="image-grid">
+          {localImages.map((img, index) => (
+            <View key={index} className="image-item">
+              <Image
+                className="preview-image"
+                src={img}
+                mode="aspectFill"
+                onClick={() => handlePreviewImage(index)}
+              />
+              <View className="remove-btn" onClick={() => handleRemoveImage(index)}>
+                ×
+              </View>
+            </View>
+          ))}
+          {localImages.length < MAX_IMAGES && (
+            <View className="add-image-btn" onClick={handleChooseImage}>
+              <Text className="add-icon">+</Text>
+              <Text className="add-text">添加图片</Text>
+            </View>
+          )}
+        </View>
+        <Text className="image-hint">支持从相册选择或拍照，最多{MAX_IMAGES}张</Text>
+      </View>
+
+      {/* 备注 */}
+      <View className="section">
+        <Text className="section-title">备注</Text>
+        <Textarea
+          className="note-input"
+          placeholder="添加备注（可选）"
+          value={note}
+          onInput={(e) => setNote(e.detail.value)}
+          maxlength={500}
+        />
+      </View>
+
+      {/* 提交按钮 */}
+      <View className="submit-section">
+        <View className={`submit-btn ${submitting ? "disabled" : ""}`} onClick={handleSubmit}>
+          {submitting ? "保存中..." : "保存记录"}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/pages/medical/index/index.config.ts
+++ b/src/pages/medical/index/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: "检查记录",
+});

--- a/src/pages/medical/index/index.css
+++ b/src/pages/medical/index/index.css
@@ -1,0 +1,94 @@
+.medical-page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+  padding-bottom: 40px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 32px;
+  background-color: #fff;
+}
+
+.title {
+  font-size: 36px;
+  font-weight: 600;
+  color: #333;
+}
+
+.add-btn {
+  padding: 12px 24px;
+  background-color: #07c160;
+  color: #fff;
+  font-size: 28px;
+  border-radius: 8px;
+}
+
+.loading,
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 120px 32px;
+}
+
+.empty-text {
+  font-size: 32px;
+  color: #999;
+  margin-bottom: 16px;
+}
+
+.empty-hint {
+  font-size: 26px;
+  color: #ccc;
+}
+
+.record-list {
+  padding: 24px;
+}
+
+.record-item {
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 28px;
+  margin-bottom: 20px;
+}
+
+.record-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.record-date {
+  font-size: 28px;
+  color: #666;
+}
+
+.image-count {
+  font-size: 24px;
+  color: #999;
+}
+
+.image-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.thumbnail {
+  width: 160px;
+  height: 160px;
+  border-radius: 8px;
+}
+
+.record-note {
+  font-size: 26px;
+  color: #999;
+  line-height: 1.5;
+}

--- a/src/pages/medical/index/index.tsx
+++ b/src/pages/medical/index/index.tsx
@@ -1,0 +1,107 @@
+import { View, Text, Image } from "@tarojs/components";
+import Taro, { useDidShow } from "@tarojs/taro";
+import { useState } from "react";
+import { getRecentMedicalRecords } from "../../../services/medical";
+import { formatDisplayDate } from "../../../utils/date";
+import type { MedicalRecord } from "../../../types";
+import "./index.css";
+
+export default function MedicalIndex() {
+  const [records, setRecords] = useState<MedicalRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useDidShow(() => {
+    loadRecords();
+  });
+
+  const loadRecords = async () => {
+    setLoading(true);
+    try {
+      const data = await getRecentMedicalRecords(50);
+      setRecords(data);
+    } catch (error) {
+      console.error("加载记录失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAdd = () => {
+    Taro.navigateTo({ url: "/pages/medical/add/index" });
+  };
+
+  const handleDelete = async (id: string) => {
+    const res = await Taro.showModal({
+      title: "确认删除",
+      content: "确定要删除这条记录吗？",
+    });
+
+    if (res.confirm) {
+      try {
+        const { deleteMedicalRecord } = await import("../../../services/medical");
+        await deleteMedicalRecord(id);
+        Taro.showToast({ title: "已删除", icon: "success" });
+        loadRecords();
+      } catch {
+        Taro.showToast({ title: "删除失败", icon: "none" });
+      }
+    }
+  };
+
+  const handlePreviewImage = (record: MedicalRecord, index: number) => {
+    Taro.previewImage({
+      current: record.images[index],
+      urls: record.images,
+    });
+  };
+
+  return (
+    <View className="medical-page">
+      <View className="header">
+        <Text className="title">检查记录</Text>
+        <View className="add-btn" onClick={handleAdd}>
+          + 添加
+        </View>
+      </View>
+
+      {loading ? (
+        <View className="loading">加载中...</View>
+      ) : records.length === 0 ? (
+        <View className="empty">
+          <Text className="empty-text">暂无记录</Text>
+          <Text className="empty-hint">点击右上角添加检查记录</Text>
+        </View>
+      ) : (
+        <View className="record-list">
+          {records.map((record) => (
+            <View
+              key={record._id}
+              className="record-item"
+              onLongPress={() => handleDelete(record._id!)}
+            >
+              <View className="record-header">
+                <Text className="record-date">{formatDisplayDate(record.date)}</Text>
+                <Text className="image-count">{record.images.length}张图片</Text>
+              </View>
+
+              <View className="image-grid">
+                {record.images.map((img, idx) => (
+                  <Image
+                    key={idx}
+                    className="thumbnail"
+                    src={img}
+                    mode="aspectFill"
+                    onClick={() => handlePreviewImage(record, idx)}
+                  />
+                ))}
+              </View>
+
+              {record.note && <Text className="record-note">{record.note}</Text>}
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/services/medical.test.ts
+++ b/src/services/medical.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { addMedicalRecord, getRecentMedicalRecords, deleteMedicalRecord } from "./medical";
+
+// Mock getOpenId to return a test user
+vi.mock("../utils/cloud", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../utils/cloud")>();
+  return {
+    ...original,
+    getOpenId: vi.fn().mockResolvedValue("test_user_001"),
+  };
+});
+
+describe("medical service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("addMedicalRecord", () => {
+    it("should add a medical record and return id", async () => {
+      const id = await addMedicalRecord({
+        date: "2026-04-11",
+        images: ["cloud://test/image1.jpg"],
+      });
+
+      expect(id).toBeDefined();
+      expect(id).toMatch(/^fake_/);
+    });
+
+    it("should add record with note", async () => {
+      const id = await addMedicalRecord({
+        date: "2026-04-11",
+        images: ["cloud://test/image1.jpg", "cloud://test/image2.jpg"],
+        note: "肠镜检查报告",
+      });
+
+      expect(id).toBeDefined();
+    });
+  });
+
+  describe("getRecentMedicalRecords", () => {
+    it("should return records for current user", async () => {
+      await addMedicalRecord({
+        date: "2026-04-11",
+        images: ["cloud://test/image1.jpg"],
+      });
+
+      const records = await getRecentMedicalRecords(10);
+      expect(records.length).toBeGreaterThan(0);
+      expect(records[0].userId).toBe("test_user_001");
+    });
+
+    it("should respect limit parameter", async () => {
+      for (let i = 0; i < 5; i++) {
+        await addMedicalRecord({
+          date: `2026-04-${10 + i}`,
+          images: ["cloud://test/image.jpg"],
+        });
+      }
+
+      const records = await getRecentMedicalRecords(3);
+      expect(records.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe("deleteMedicalRecord", () => {
+    it("should delete a record", async () => {
+      const id = await addMedicalRecord({
+        date: "2026-04-11",
+        images: ["cloud://test/image1.jpg"],
+      });
+
+      const beforeRecords = await getRecentMedicalRecords(100);
+      const countBefore = beforeRecords.length;
+
+      await deleteMedicalRecord(id);
+
+      const afterRecords = await getRecentMedicalRecords(100);
+      expect(afterRecords.length).toBe(countBefore - 1);
+    });
+  });
+});

--- a/src/services/medical.ts
+++ b/src/services/medical.ts
@@ -1,0 +1,67 @@
+import Taro from "@tarojs/taro";
+import { getDatabase, getOpenId } from "../utils/cloud";
+import type { MedicalRecord } from "../types";
+
+const COLLECTION = "medical_records";
+const CLOUD_PATH_PREFIX = "medical-images";
+
+// 上传图片到云存储
+export async function uploadImage(filePath: string): Promise<string> {
+  const userId = await getOpenId();
+  const timestamp = Date.now();
+  const ext = filePath.split(".").pop() || "jpg";
+  const cloudPath = `${CLOUD_PATH_PREFIX}/${userId}/${timestamp}_${Math.random().toString(36).slice(2)}.${ext}`;
+
+  const res = await Taro.cloud.uploadFile({
+    cloudPath,
+    filePath,
+  });
+
+  return res.fileID;
+}
+
+// 批量上传图片
+export async function uploadImages(filePaths: string[]): Promise<string[]> {
+  const results = await Promise.all(filePaths.map((path) => uploadImage(path)));
+  return results;
+}
+
+// 添加医疗检查记录
+export async function addMedicalRecord(
+  data: Omit<MedicalRecord, "_id" | "userId" | "createdAt">,
+): Promise<string> {
+  const db = getDatabase();
+  const userId = await getOpenId();
+
+  const res = await db.collection(COLLECTION).add({
+    data: {
+      ...data,
+      userId,
+      createdAt: new Date(),
+    },
+  });
+
+  return res._id as string;
+}
+
+// 获取最近的医疗检查记录
+export async function getRecentMedicalRecords(limit: number = 20): Promise<MedicalRecord[]> {
+  const db = getDatabase();
+  const userId = await getOpenId();
+
+  const res = await db
+    .collection(COLLECTION)
+    .where({ userId })
+    .orderBy("createdAt", "desc")
+    .limit(limit)
+    .get();
+
+  return res.data as MedicalRecord[];
+}
+
+// 删除医疗检查记录
+export async function deleteMedicalRecord(id: string): Promise<void> {
+  const db = getDatabase();
+
+  await db.collection(COLLECTION).doc(id).remove();
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,10 +68,7 @@ export interface MedicalRecord {
   _id?: string;
   userId: string;
   date: string;
-  type: "blood" | "stool" | "colonoscopy" | "gastroscopy" | "ct" | "ultrasound" | "other";
-  hospital?: string;
-  result?: string;
-  images?: string[];
+  images: string[]; // 云存储 fileID
   note?: string;
   createdAt: Date;
 }


### PR DESCRIPTION
## Summary
- Add medical record pages (list + add) for saving exam report images
- Support uploading multiple images from album or camera
- Images stored in WeChat cloud storage
- Thumbnails displayed in list with full-screen preview support

Closes #8

## Test plan
- [x] Integration tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [ ] E2E test in WeChat DevTools
- [ ] Test image upload from album
- [ ] Test image capture from camera
- [ ] Test image preview and swipe

🤖 Generated with [Claude Code](https://claude.ai/code)