### PR TITLE
feat(home): implement daily overview with date navigation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit -m ':*)"
+    ]
+  }
+}

--- a/src/pages/index/index.css
+++ b/src/pages/index/index.css
@@ -1,72 +1,157 @@
-.index {
+.overview-page {
   min-height: 100vh;
   background-color: #f5f5f5;
+  padding-bottom: 40px;
 }
 
-.header {
-  background: linear-gradient(135deg, #07c160 0%, #10b981 100%);
-  padding: 60px 32px 80px;
-  color: #fff;
-}
-
-.title {
-  font-size: 48px;
-  font-weight: 700;
-  display: block;
-  margin-bottom: 12px;
-}
-
-.subtitle {
-  font-size: 28px;
-  opacity: 0.9;
-}
-
-.menu-list {
-  margin: -40px 24px 0;
-  background-color: #fff;
-  border-radius: 20px;
-  overflow: hidden;
-  box-shadow: 0 4px 20px rgb(0 0 0 / 8%);
-}
-
-.menu-item {
+/* 日期选择器 */
+.date-header {
   display: flex;
+  justify-content: center;
   align-items: center;
   padding: 32px;
+  background-color: #fff;
+  gap: 32px;
+}
+
+.date-arrow {
+  font-size: 36px;
+  color: #07c160;
+  padding: 16px;
+}
+
+.date-text {
+  font-size: 36px;
+  font-weight: 600;
+  color: #333;
+}
+
+/* 整体感受 */
+.feeling-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 24px;
+  padding: 28px 32px;
+  background-color: #fff;
+  border-radius: 16px;
+}
+
+.feeling-label {
+  font-size: 30px;
+  color: #666;
+}
+
+.feeling-value {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.feeling-emoji {
+  font-size: 40px;
+}
+
+.feeling-text {
+  font-size: 30px;
+  font-weight: 500;
+  color: #333;
+}
+
+.feeling-empty {
+  font-size: 30px;
+  color: #ccc;
+}
+
+/* 加载状态 */
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 80px;
+  color: #999;
+  font-size: 28px;
+}
+
+/* 记录容器 */
+.records-container {
+  padding: 0 24px;
+}
+
+/* 记录卡片 */
+.record-card {
+  background-color: #fff;
+  border-radius: 16px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 28px;
   border-bottom: 1px solid #f0f0f0;
 }
 
-.menu-item:last-child {
-  border-bottom: none;
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
-.menu-item.disabled {
-  opacity: 0.5;
+.card-icon {
+  font-size: 36px;
 }
 
-.menu-icon {
-  font-size: 40px;
-  margin-right: 24px;
-}
-
-.menu-content {
-  flex: 1;
-}
-
-.menu-title {
-  font-size: 32px;
-  font-weight: 500;
+.card-title {
+  font-size: 30px;
+  font-weight: 600;
   color: #333;
-  display: block;
-  margin-bottom: 8px;
 }
 
-.menu-desc {
+.card-count {
   font-size: 24px;
   color: #999;
 }
 
-.menu-arrow {
+.card-add-btn {
   font-size: 40px;
+  color: #07c160;
+  padding: 8px 16px;
+}
+
+.card-content {
+  padding: 20px 28px;
+  min-height: 60px;
+}
+
+.empty-hint {
+  font-size: 26px;
   color: #ccc;
+  text-align: center;
+  display: block;
+  padding: 20px 0;
+}
+
+.record-item {
+  display: flex;
+  align-items: center;
+  padding: 12px 0;
+  gap: 16px;
+}
+
+.record-time {
+  font-size: 26px;
+  color: #999;
+  min-width: 90px;
+}
+
+.record-desc {
+  font-size: 28px;
+  color: #333;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/pages/index/index.css
+++ b/src/pages/index/index.css
@@ -26,43 +26,6 @@
   color: #333;
 }
 
-/* 整体感受 */
-.feeling-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: 24px;
-  padding: 28px 32px;
-  background-color: #fff;
-  border-radius: 16px;
-}
-
-.feeling-label {
-  font-size: 30px;
-  color: #666;
-}
-
-.feeling-value {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.feeling-emoji {
-  font-size: 40px;
-}
-
-.feeling-text {
-  font-size: 30px;
-  font-weight: 500;
-  color: #333;
-}
-
-.feeling-empty {
-  font-size: 30px;
-  color: #ccc;
-}
-
 /* 加载状态 */
 .loading {
   display: flex;

--- a/src/pages/index/index.css
+++ b/src/pages/index/index.css
@@ -20,6 +20,10 @@
   padding: 16px;
 }
 
+.date-arrow.disabled {
+  color: #ccc;
+}
+
 .date-text {
   font-size: 36px;
   font-weight: 600;

--- a/src/pages/index/index.css
+++ b/src/pages/index/index.css
@@ -114,6 +114,11 @@
   min-width: 90px;
 }
 
+.record-feeling {
+  font-size: 28px;
+  margin-right: 8px;
+}
+
 .record-desc {
   font-size: 28px;
   color: #333;

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,65 +1,249 @@
-import { View, Text } from "@tarojs/components";
-import Taro from "@tarojs/taro";
+import { View, Text, Picker } from "@tarojs/components";
+import Taro, { useDidShow } from "@tarojs/taro";
+import { useState, useCallback } from "react";
+import { getSymptomRecordsByDate } from "../../services/symptom";
+import { getMealRecordsByDate } from "../../services/meal";
+import { getStoolRecordsByDate } from "../../services/stool";
+import { getMedicationRecordsByDate } from "../../services/medication";
+import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
+import type { SymptomRecord, MealRecord, StoolRecord, MedicationRecord } from "../../types";
 import "./index.css";
 
+const FEELING_MAP: Record<number, { emoji: string; label: string }> = {
+  1: { emoji: "😫", label: "很差" },
+  2: { emoji: "😟", label: "较差" },
+  3: { emoji: "😐", label: "一般" },
+  4: { emoji: "😊", label: "良好" },
+  5: { emoji: "😄", label: "很好" },
+};
+
 export default function Index() {
+  const [currentDate, setCurrentDate] = useState(formatDate());
+  const [loading, setLoading] = useState(true);
+  const [symptomRecords, setSymptomRecords] = useState<SymptomRecord[]>([]);
+  const [mealRecords, setMealRecords] = useState<MealRecord[]>([]);
+  const [stoolRecords, setStoolRecords] = useState<StoolRecord[]>([]);
+  const [medicationRecords, setMedicationRecords] = useState<MedicationRecord[]>([]);
+
+  const loadData = useCallback(async (date: string) => {
+    setLoading(true);
+    try {
+      const [symptoms, meals, stools, medications] = await Promise.all([
+        getSymptomRecordsByDate(date),
+        getMealRecordsByDate(date),
+        getStoolRecordsByDate(date),
+        getMedicationRecordsByDate(date),
+      ]);
+      setSymptomRecords(symptoms);
+      setMealRecords(meals);
+      setStoolRecords(stools);
+      setMedicationRecords(medications);
+    } catch (error) {
+      console.error("加载数据失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useDidShow(() => {
+    loadData(currentDate);
+  });
+
+  const handlePrevDate = () => {
+    const newDate = getPrevDate(currentDate);
+    setCurrentDate(newDate);
+    loadData(newDate);
+  };
+
+  const handleNextDate = () => {
+    const newDate = getNextDate(currentDate);
+    setCurrentDate(newDate);
+    loadData(newDate);
+  };
+
+  const handleDateChange = (e: { detail: { value: string } }) => {
+    const newDate = e.detail.value;
+    setCurrentDate(newDate);
+    loadData(newDate);
+  };
+
   const handleNavigate = (path: string) => {
     Taro.navigateTo({ url: path });
   };
 
+  // 获取整体感受（取最新一条症状记录）
+  const overallFeeling = symptomRecords.length > 0 ? symptomRecords[0].overallFeeling : null;
+  const feelingInfo = overallFeeling ? FEELING_MAP[overallFeeling] : null;
+
   return (
-    <View className="index">
-      <View className="header">
-        <Text className="title">MyGut</Text>
-        <Text className="subtitle">肠胃健康追踪</Text>
+    <View className="overview-page">
+      {/* 日期选择器 */}
+      <View className="date-header">
+        <Text className="date-arrow" onClick={handlePrevDate}>
+          ◀
+        </Text>
+        <Picker mode="date" value={currentDate} onChange={handleDateChange}>
+          <Text className="date-text">
+            {currentDate} {getWeekday(currentDate)}
+          </Text>
+        </Picker>
+        <Text className="date-arrow" onClick={handleNextDate}>
+          ▶
+        </Text>
       </View>
 
-      <View className="menu-list">
-        <View className="menu-item" onClick={() => handleNavigate("/pages/symptom/index/index")}>
-          <Text className="menu-icon">🩺</Text>
-          <View className="menu-content">
-            <Text className="menu-title">身体状态</Text>
-            <Text className="menu-desc">记录症状和整体感受</Text>
+      {/* 整体感受 */}
+      <View className="feeling-card">
+        <Text className="feeling-label">整体感受</Text>
+        {feelingInfo ? (
+          <View className="feeling-value">
+            <Text className="feeling-emoji">{feelingInfo.emoji}</Text>
+            <Text className="feeling-text">{feelingInfo.label}</Text>
           </View>
-          <Text className="menu-arrow">›</Text>
-        </View>
-
-        <View className="menu-item" onClick={() => handleNavigate("/pages/meal/index/index")}>
-          <Text className="menu-icon">🍚</Text>
-          <View className="menu-content">
-            <Text className="menu-title">饮食记录</Text>
-            <Text className="menu-desc">记录每日饮食</Text>
-          </View>
-          <Text className="menu-arrow">›</Text>
-        </View>
-
-        <View className="menu-item" onClick={() => handleNavigate("/pages/stool/index/index")}>
-          <Text className="menu-icon">🚽</Text>
-          <View className="menu-content">
-            <Text className="menu-title">排便记录</Text>
-            <Text className="menu-desc">记录排便情况</Text>
-          </View>
-          <Text className="menu-arrow">›</Text>
-        </View>
-
-        <View className="menu-item" onClick={() => handleNavigate("/pages/medication/add/index")}>
-          <Text className="menu-icon">💊</Text>
-          <View className="menu-content">
-            <Text className="menu-title">用药记录</Text>
-            <Text className="menu-desc">记录每日用药</Text>
-          </View>
-          <Text className="menu-arrow">›</Text>
-        </View>
-
-        <View className="menu-item disabled">
-          <Text className="menu-icon">📋</Text>
-          <View className="menu-content">
-            <Text className="menu-title">医疗检查</Text>
-            <Text className="menu-desc">记录检查报告</Text>
-          </View>
-          <Text className="menu-arrow">›</Text>
-        </View>
+        ) : (
+          <Text className="feeling-empty">--</Text>
+        )}
       </View>
+
+      {loading ? (
+        <View className="loading">加载中...</View>
+      ) : (
+        <View className="records-container">
+          {/* 身体状态 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">🩺</Text>
+                <Text className="card-title">身体状态</Text>
+                <Text className="card-count">[{symptomRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/symptom/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/symptom/index/index")}
+            >
+              {symptomRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                symptomRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time || "--:--"}</Text>
+                    <Text className="record-desc">
+                      {record.symptoms.map((s) => s.type).join("、") || "无症状"}
+                    </Text>
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+
+          {/* 饮食记录 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">🍚</Text>
+                <Text className="card-title">饮食</Text>
+                <Text className="card-count">[{mealRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/meal/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/meal/index/index")}
+            >
+              {mealRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                mealRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time}</Text>
+                    <Text className="record-desc">{record.foods.join("、")}</Text>
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+
+          {/* 排便记录 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">🚽</Text>
+                <Text className="card-title">排便</Text>
+                <Text className="card-count">[{stoolRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/stool/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/stool/index/index")}
+            >
+              {stoolRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                stoolRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time}</Text>
+                    <Text className="record-desc">类型{record.type}</Text>
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+
+          {/* 用药记录 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">💊</Text>
+                <Text className="card-title">用药</Text>
+                <Text className="card-count">[{medicationRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/medication/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/medication/index/index")}
+            >
+              {medicationRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                medicationRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time}</Text>
+                    <Text className="record-desc">
+                      {record.name}
+                      {record.dosage ? ` ${record.dosage}` : ""}
+                    </Text>
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+        </View>
+      )}
     </View>
   );
 }

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -173,6 +173,41 @@ export default function Index() {
             </View>
           </View>
 
+          {/* 用药记录 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">💊</Text>
+                <Text className="card-title">用药</Text>
+                <Text className="card-count">[{medicationRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/medication/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/medication/index/index")}
+            >
+              {medicationRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                medicationRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time}</Text>
+                    <Text className="record-desc">
+                      {record.name}
+                      {record.dosage ? ` ${record.dosage}` : ""}
+                    </Text>
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+
           {/* 饮食记录 */}
           <View className="record-card">
             <View className="card-header">
@@ -244,8 +279,6 @@ export default function Index() {
               )}
             </View>
           </View>
-
-          {/* 用药记录 */}
           <View className="record-card">
             <View className="card-header">
               <View className="card-title-row">

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -9,14 +9,6 @@ import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/da
 import type { SymptomRecord, MealRecord, StoolRecord, MedicationRecord } from "../../types";
 import "./index.css";
 
-const FEELING_MAP: Record<number, { emoji: string; label: string }> = {
-  1: { emoji: "😫", label: "很差" },
-  2: { emoji: "😟", label: "较差" },
-  3: { emoji: "😐", label: "一般" },
-  4: { emoji: "😊", label: "良好" },
-  5: { emoji: "😄", label: "很好" },
-};
-
 export default function Index() {
   const [currentDate, setCurrentDate] = useState(formatDate());
   const [loading, setLoading] = useState(true);
@@ -72,10 +64,6 @@ export default function Index() {
     Taro.navigateTo({ url: path });
   };
 
-  // 获取整体感受（取最新一条症状记录）
-  const overallFeeling = symptomRecords.length > 0 ? symptomRecords[0].overallFeeling : null;
-  const feelingInfo = overallFeeling ? FEELING_MAP[overallFeeling] : null;
-
   return (
     <View className="overview-page">
       {/* 日期选择器 */}
@@ -91,19 +79,6 @@ export default function Index() {
         <Text className="date-arrow" onClick={handleNextDate}>
           ▶
         </Text>
-      </View>
-
-      {/* 整体感受 */}
-      <View className="feeling-card">
-        <Text className="feeling-label">整体感受</Text>
-        {feelingInfo ? (
-          <View className="feeling-value">
-            <Text className="feeling-emoji">{feelingInfo.emoji}</Text>
-            <Text className="feeling-text">{feelingInfo.label}</Text>
-          </View>
-        ) : (
-          <Text className="feeling-empty">--</Text>
-        )}
       </View>
 
       {loading ? (

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -48,7 +48,11 @@ export default function Index() {
     loadData(newDate);
   };
 
+  const today = formatDate();
+  const isToday = currentDate === today;
+
   const handleNextDate = () => {
+    if (isToday) return;
     const newDate = getNextDate(currentDate);
     setCurrentDate(newDate);
     loadData(newDate);
@@ -71,12 +75,12 @@ export default function Index() {
         <Text className="date-arrow" onClick={handlePrevDate}>
           ◀
         </Text>
-        <Picker mode="date" value={currentDate} onChange={handleDateChange}>
+        <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
           <Text className="date-text">
             {currentDate} {getWeekday(currentDate)}
           </Text>
         </Picker>
-        <Text className="date-arrow" onClick={handleNextDate}>
+        <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
           ▶
         </Text>
       </View>

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -7,6 +7,8 @@ import { getStoolRecordsByDate } from "../../services/stool";
 import { getMedicationRecordsByDate } from "../../services/medication";
 import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
 import { SYMPTOM_TYPES, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
+import { AMOUNT_OPTIONS } from "../../constants/meal";
+import { BRISTOL_TYPES, STOOL_AMOUNTS } from "../../constants/stool";
 import type {
   SymptomRecord,
   MealRecord,
@@ -24,6 +26,34 @@ const formatSymptom = (symptom: Symptom): string => {
   const typeLabel = SYMPTOM_TYPES.find((t) => t.value === symptom.type)?.label || symptom.type;
   const severityLabel = SEVERITY_OPTIONS.find((s) => s.value === symptom.severity)?.label || "";
   return `${typeLabel}(${severityLabel})`;
+};
+
+const getAmountEmoji = (amount: number): string => {
+  return AMOUNT_OPTIONS.find((a) => a.value === amount)?.emoji || "🍚";
+};
+
+const getBristolEmoji = (type: number): string => {
+  return BRISTOL_TYPES.find((b) => b.value === type)?.emoji || "";
+};
+
+const getStoolAmountLabel = (amount: number): string => {
+  return STOOL_AMOUNTS.find((a) => a.value === amount)?.label || "";
+};
+
+const formatStoolAbnormal = (record: StoolRecord): string => {
+  const abnormals: string[] = [];
+  if (record.hasBlood) abnormals.push("带血");
+  if (record.hasMucus) abnormals.push("带粘液");
+  if (record.color !== "normal") {
+    const colorLabels: Record<string, string> = {
+      dark: "深色",
+      light: "浅色",
+      red: "带红",
+      black: "黑色",
+    };
+    abnormals.push(colorLabels[record.color] || "");
+  }
+  return abnormals.length > 0 ? abnormals.join("、") : "";
 };
 
 export default function Index() {
@@ -168,6 +198,7 @@ export default function Index() {
                 mealRecords.slice(0, 3).map((record) => (
                   <View key={record._id} className="record-item">
                     <Text className="record-time">{record.time}</Text>
+                    <Text className="record-feeling">{getAmountEmoji(record.amount)}</Text>
                     <Text className="record-desc">{record.foods.join("、")}</Text>
                   </View>
                 ))
@@ -197,12 +228,19 @@ export default function Index() {
               {stoolRecords.length === 0 ? (
                 <Text className="empty-hint">暂无记录</Text>
               ) : (
-                stoolRecords.slice(0, 3).map((record) => (
-                  <View key={record._id} className="record-item">
-                    <Text className="record-time">{record.time}</Text>
-                    <Text className="record-desc">类型{record.type}</Text>
-                  </View>
-                ))
+                stoolRecords.slice(0, 3).map((record) => {
+                  const abnormal = formatStoolAbnormal(record);
+                  return (
+                    <View key={record._id} className="record-item">
+                      <Text className="record-time">{record.time}</Text>
+                      <Text className="record-feeling">{getBristolEmoji(record.type)}</Text>
+                      <Text className="record-desc">
+                        {getStoolAmountLabel(record.amount)}
+                        {abnormal && ` · ${abnormal}`}
+                      </Text>
+                    </View>
+                  );
+                })
               )}
             </View>
           </View>

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -9,6 +9,14 @@ import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/da
 import type { SymptomRecord, MealRecord, StoolRecord, MedicationRecord } from "../../types";
 import "./index.css";
 
+const FEELING_EMOJI: Record<number, string> = {
+  1: "😫",
+  2: "😟",
+  3: "😐",
+  4: "😊",
+  5: "😄",
+};
+
 export default function Index() {
   const [currentDate, setCurrentDate] = useState(formatDate());
   const [loading, setLoading] = useState(true);
@@ -114,9 +122,12 @@ export default function Index() {
                 symptomRecords.slice(0, 3).map((record) => (
                   <View key={record._id} className="record-item">
                     <Text className="record-time">{record.time || "--:--"}</Text>
-                    <Text className="record-desc">
-                      {record.symptoms.map((s) => s.type).join("、") || "无症状"}
-                    </Text>
+                    <Text className="record-feeling">{FEELING_EMOJI[record.overallFeeling]}</Text>
+                    {record.symptoms.length > 0 && (
+                      <Text className="record-desc">
+                        {record.symptoms.map((s) => s.type).join("、")}
+                      </Text>
+                    )}
                   </View>
                 ))
               )}

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -6,15 +6,24 @@ import { getMealRecordsByDate } from "../../services/meal";
 import { getStoolRecordsByDate } from "../../services/stool";
 import { getMedicationRecordsByDate } from "../../services/medication";
 import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
-import type { SymptomRecord, MealRecord, StoolRecord, MedicationRecord } from "../../types";
+import { SYMPTOM_TYPES, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
+import type {
+  SymptomRecord,
+  MealRecord,
+  StoolRecord,
+  MedicationRecord,
+  Symptom,
+} from "../../types";
 import "./index.css";
 
-const FEELING_EMOJI: Record<number, string> = {
-  1: "😫",
-  2: "😟",
-  3: "😐",
-  4: "😊",
-  5: "😄",
+const getFeelingEmoji = (value: number): string => {
+  return FEELING_OPTIONS.find((f) => f.value === value)?.emoji || "😐";
+};
+
+const formatSymptom = (symptom: Symptom): string => {
+  const typeLabel = SYMPTOM_TYPES.find((t) => t.value === symptom.type)?.label || symptom.type;
+  const severityLabel = SEVERITY_OPTIONS.find((s) => s.value === symptom.severity)?.label || "";
+  return `${typeLabel}(${severityLabel})`;
 };
 
 export default function Index() {
@@ -122,10 +131,10 @@ export default function Index() {
                 symptomRecords.slice(0, 3).map((record) => (
                   <View key={record._id} className="record-item">
                     <Text className="record-time">{record.time || "--:--"}</Text>
-                    <Text className="record-feeling">{FEELING_EMOJI[record.overallFeeling]}</Text>
+                    <Text className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</Text>
                     {record.symptoms.length > 0 && (
                       <Text className="record-desc">
-                        {record.symptoms.map((s) => s.type).join("、")}
+                        {record.symptoms.map(formatSymptom).join("、")}
                       </Text>
                     )}
                   </View>

--- a/src/services/meal.test.ts
+++ b/src/services/meal.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { addMealRecord, getRecentMealRecords, deleteMealRecord } from "./meal";
+import {
+  addMealRecord,
+  getRecentMealRecords,
+  deleteMealRecord,
+  getMealRecordsByDate,
+} from "./meal";
 
 // Mock getOpenId to return a test user
 vi.mock("../utils/cloud", async (importOriginal) => {
@@ -86,6 +91,38 @@ describe("meal service", () => {
 
       const afterRecords = await getRecentMealRecords(100);
       expect(afterRecords.length).toBe(countBefore - 1);
+    });
+  });
+
+  describe("getMealRecordsByDate", () => {
+    it("should return records for specific date", async () => {
+      await addMealRecord({
+        date: "2026-04-15",
+        time: "08:00",
+        foods: ["早餐"],
+        amount: 2,
+      });
+      await addMealRecord({
+        date: "2026-04-15",
+        time: "12:00",
+        foods: ["午餐"],
+        amount: 2,
+      });
+      await addMealRecord({
+        date: "2026-04-16",
+        time: "08:00",
+        foods: ["其他日期"],
+        amount: 2,
+      });
+
+      const records = await getMealRecordsByDate("2026-04-15");
+      expect(records.length).toBe(2);
+      expect(records.every((r) => r.date === "2026-04-15")).toBe(true);
+    });
+
+    it("should return empty array for date with no records", async () => {
+      const records = await getMealRecordsByDate("2020-01-01");
+      expect(records).toEqual([]);
     });
   });
 });

--- a/src/services/meal.ts
+++ b/src/services/meal.ts
@@ -42,3 +42,13 @@ export async function deleteMealRecord(id: string): Promise<void> {
 
   await db.collection(COLLECTION).doc(id).remove();
 }
+
+// 获取指定日期的饮食记录
+export async function getMealRecordsByDate(date: string): Promise<MealRecord[]> {
+  const db = getDatabase();
+  const userId = await getOpenId();
+
+  const res = await db.collection(COLLECTION).where({ userId, date }).orderBy("time", "asc").get();
+
+  return res.data as MealRecord[];
+}

--- a/src/services/medication.ts
+++ b/src/services/medication.ts
@@ -42,3 +42,13 @@ export async function deleteMedicationRecord(id: string): Promise<void> {
 
   await db.collection(COLLECTION).doc(id).remove();
 }
+
+// 获取指定日期的用药记录
+export async function getMedicationRecordsByDate(date: string): Promise<MedicationRecord[]> {
+  const db = getDatabase();
+  const userId = await getOpenId();
+
+  const res = await db.collection(COLLECTION).where({ userId, date }).orderBy("time", "asc").get();
+
+  return res.data as MedicationRecord[];
+}

--- a/src/services/stool.ts
+++ b/src/services/stool.ts
@@ -39,3 +39,13 @@ export async function deleteStoolRecord(id: string): Promise<void> {
 
   await db.collection(COLLECTION).doc(id).remove();
 }
+
+// 获取指定日期的排便记录
+export async function getStoolRecordsByDate(date: string): Promise<StoolRecord[]> {
+  const db = getDatabase();
+  const userId = await getOpenId();
+
+  const res = await db.collection(COLLECTION).where({ userId, date }).orderBy("time", "asc").get();
+
+  return res.data as StoolRecord[];
+}

--- a/src/services/symptom.ts
+++ b/src/services/symptom.ts
@@ -42,3 +42,17 @@ export async function deleteSymptomRecord(id: string): Promise<void> {
 
   await db.collection(COLLECTION).doc(id).remove();
 }
+
+// 获取指定日期的症状记录
+export async function getSymptomRecordsByDate(date: string): Promise<SymptomRecord[]> {
+  const db = getDatabase();
+  const userId = await getOpenId();
+
+  const res = await db
+    .collection(COLLECTION)
+    .where({ userId, date })
+    .orderBy("createdAt", "desc")
+    .get();
+
+  return res.data as SymptomRecord[];
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -18,3 +18,24 @@ export function formatDisplayDate(dateStr: string): string {
   const date = new Date(dateStr);
   return `${date.getMonth() + 1}月${date.getDate()}日`;
 }
+
+// 获取星期几
+const WEEKDAYS = ["周日", "周一", "周二", "周三", "周四", "周五", "周六"];
+export function getWeekday(dateStr: string): string {
+  const date = new Date(dateStr);
+  return WEEKDAYS[date.getDay()];
+}
+
+// 获取前一天日期
+export function getPrevDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  date.setDate(date.getDate() - 1);
+  return formatDate(date);
+}
+
+// 获取后一天日期
+export function getNextDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  date.setDate(date.getDate() + 1);
+  return formatDate(date);
+}


### PR DESCRIPTION
## Summary

- Replace menu navigation with daily overview showing all records for selected date
- Add date navigation: picker + prev/next day arrows
- Show overall feeling from symptom records
- Display record cards for symptom, meal, stool, medication

Closes #9

## Test plan

- [x] Integration tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Manual test: date picker works
- [ ] Manual test: prev/next arrows work
- [ ] Manual test: records display correctly
- [ ] Manual test: empty state shows "暂无记录"

🤖 Generated with [Claude Code](https://claude.ai/code)