### PR TITLE
feat(user): add user profile with avatar and nickname

### DIFF
--- a/src/components/ProfilePopup/index.css
+++ b/src/components/ProfilePopup/index.css
@@ -1,9 +1,6 @@
 .popup-mask {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background-color: rgb(0 0 0 / 50%);
   display: flex;
   align-items: center;

--- a/src/components/ProfilePopup/index.css
+++ b/src/components/ProfilePopup/index.css
@@ -1,0 +1,123 @@
+.popup-mask {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.popup-content {
+  width: 600px;
+  background-color: #fff;
+  border-radius: 24px;
+  overflow: hidden;
+}
+
+.popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 32px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.popup-title {
+  font-size: 32px;
+  font-weight: 600;
+  color: #333;
+}
+
+.popup-close {
+  font-size: 36px;
+  color: #999;
+  padding: 8px;
+}
+
+.popup-body {
+  padding: 48px 32px;
+}
+
+.avatar-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 48px;
+}
+
+.avatar-button {
+  width: 160px;
+  height: 160px;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: none;
+  line-height: 1;
+}
+
+.avatar-button::after {
+  display: none;
+}
+
+.avatar-image {
+  width: 160px;
+  height: 160px;
+  border-radius: 80px;
+}
+
+.avatar-placeholder {
+  width: 160px;
+  height: 160px;
+  border-radius: 80px;
+  background-color: #e0e0e0;
+}
+
+.avatar-hint {
+  font-size: 24px;
+  color: #999;
+  margin-top: 16px;
+}
+
+.nickname-section {
+  margin-bottom: 24px;
+}
+
+.nickname-label {
+  font-size: 28px;
+  color: #666;
+  display: block;
+  margin-bottom: 16px;
+}
+
+.nickname-input {
+  width: 100%;
+  height: 88px;
+  padding: 0 24px;
+  font-size: 32px;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  box-sizing: border-box;
+}
+
+.popup-footer {
+  padding: 24px 32px 32px;
+}
+
+.save-button {
+  width: 100%;
+  height: 88px;
+  background-color: #07c160;
+  color: #fff;
+  font-size: 32px;
+  font-weight: 500;
+  border: none;
+  border-radius: 12px;
+}
+
+.save-button::after {
+  display: none;
+}

--- a/src/components/ProfilePopup/index.tsx
+++ b/src/components/ProfilePopup/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { View, Text, Image, Input, Button } from "@tarojs/components";
 import Taro from "@tarojs/taro";
-import { updateUser, uploadAvatar } from "../../services/user";
+import { updateUserSettings, uploadAvatar } from "../../services/user";
 import "./index.css";
 
 interface ProfilePopupProps {
@@ -48,8 +48,8 @@ export default function ProfilePopup({
         avatarFileId = await uploadAvatar(tempAvatarPath);
       }
 
-      // 更新用户信息
-      await updateUser({
+      // 更新用户设置
+      await updateUserSettings({
         nickname: currentNickname,
         avatar: avatarFileId,
       });

--- a/src/components/ProfilePopup/index.tsx
+++ b/src/components/ProfilePopup/index.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { View, Text, Image, Input, Button } from "@tarojs/components";
+import Taro from "@tarojs/taro";
+import { updateUser, uploadAvatar } from "../../services/user";
+import "./index.css";
+
+interface ProfilePopupProps {
+  visible: boolean;
+  nickname: string;
+  avatar?: string;
+  onClose: () => void;
+  onSave: (data: { nickname: string; avatar?: string }) => void;
+}
+
+export default function ProfilePopup({
+  visible,
+  nickname,
+  avatar,
+  onClose,
+  onSave,
+}: ProfilePopupProps) {
+  const [currentNickname, setCurrentNickname] = useState(nickname);
+  const [currentAvatar, setCurrentAvatar] = useState(avatar);
+  const [tempAvatarPath, setTempAvatarPath] = useState<string>();
+  const [saving, setSaving] = useState(false);
+
+  if (!visible) return null;
+
+  const handleChooseAvatar = (e: any) => {
+    const tempPath = e.detail.avatarUrl;
+    setTempAvatarPath(tempPath);
+    setCurrentAvatar(tempPath);
+  };
+
+  const handleNicknameInput = (e: any) => {
+    setCurrentNickname(e.detail.value);
+  };
+
+  const handleSave = async () => {
+    if (saving) return;
+    setSaving(true);
+
+    try {
+      let avatarFileId = currentAvatar;
+
+      // 如果有新选择的头像，先上传
+      if (tempAvatarPath) {
+        avatarFileId = await uploadAvatar(tempAvatarPath);
+      }
+
+      // 更新用户信息
+      await updateUser({
+        nickname: currentNickname,
+        avatar: avatarFileId,
+      });
+
+      onSave({
+        nickname: currentNickname,
+        avatar: avatarFileId,
+      });
+
+      Taro.showToast({ title: "保存成功", icon: "success" });
+    } catch (error) {
+      console.error("保存失败:", error);
+      Taro.showToast({ title: "保存失败", icon: "none" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <View className="popup-mask" onClick={onClose}>
+      <View className="popup-content" onClick={(e) => e.stopPropagation()}>
+        <View className="popup-header">
+          <Text className="popup-title">编辑资料</Text>
+          <Text className="popup-close" onClick={onClose}>
+            ✕
+          </Text>
+        </View>
+
+        <View className="popup-body">
+          <View className="avatar-section">
+            <Button
+              className="avatar-button"
+              openType="chooseAvatar"
+              onChooseAvatar={handleChooseAvatar}
+            >
+              {currentAvatar ? (
+                <Image className="avatar-image" src={currentAvatar} mode="aspectFill" />
+              ) : (
+                <View className="avatar-placeholder" />
+              )}
+            </Button>
+            <Text className="avatar-hint">点击更换头像</Text>
+          </View>
+
+          <View className="nickname-section">
+            <Text className="nickname-label">昵称</Text>
+            <Input
+              className="nickname-input"
+              type="nickname"
+              value={currentNickname}
+              onInput={handleNicknameInput}
+              placeholder="请输入昵称"
+            />
+          </View>
+        </View>
+
+        <View className="popup-footer">
+          <Button className="save-button" onClick={handleSave} loading={saving}>
+            保存
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/pages/index/index.css
+++ b/src/pages/index/index.css
@@ -4,14 +4,41 @@
   padding-bottom: 40px;
 }
 
+/* 顶部栏 */
+.top-header {
+  display: flex;
+  align-items: center;
+  padding: 24px 32px;
+  background-color: #fff;
+  gap: 24px;
+}
+
+.header-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 36px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.avatar-img {
+  width: 100%;
+  height: 100%;
+}
+
+.avatar-default {
+  width: 100%;
+  height: 100%;
+  background-color: #e0e0e0;
+}
+
 /* 日期选择器 */
-.date-header {
+.date-selector {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 32px;
-  background-color: #fff;
-  gap: 32px;
+  flex: 1;
+  gap: 24px;
 }
 
 .date-arrow {

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -5,7 +5,7 @@ import { getSymptomRecordsByDate } from "../../services/symptom";
 import { getMealRecordsByDate } from "../../services/meal";
 import { getStoolRecordsByDate } from "../../services/stool";
 import { getMedicationRecordsByDate } from "../../services/medication";
-import { getCurrentUser, getDefaultNickname } from "../../services/user";
+import { getUserSettings, getDefaultNickname } from "../../services/user";
 import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
 import { SYMPTOM_TYPES, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
 import { AMOUNT_OPTIONS } from "../../constants/meal";
@@ -17,7 +17,6 @@ import type {
   StoolRecord,
   MedicationRecord,
   Symptom,
-  User,
 } from "../../types";
 import "./index.css";
 
@@ -66,7 +65,11 @@ export default function Index() {
   const [mealRecords, setMealRecords] = useState<MealRecord[]>([]);
   const [stoolRecords, setStoolRecords] = useState<StoolRecord[]>([]);
   const [medicationRecords, setMedicationRecords] = useState<MedicationRecord[]>([]);
-  const [user, setUser] = useState<User | null>(null);
+  const [userSettings, setUserSettings] = useState<{
+    userId: string;
+    nickname?: string;
+    avatar?: string;
+  } | null>(null);
   const [showProfilePopup, setShowProfilePopup] = useState(false);
 
   const loadData = useCallback(async (date: string) => {
@@ -90,18 +93,18 @@ export default function Index() {
     }
   }, []);
 
-  const loadUser = useCallback(async () => {
+  const loadUserSettings = useCallback(async () => {
     try {
-      const userData = await getCurrentUser();
-      setUser(userData);
+      const settings = await getUserSettings();
+      setUserSettings(settings);
     } catch (error) {
-      console.error("加载用户信息失败:", error);
+      console.error("加载用户设置失败:", error);
     }
   }, []);
 
   useDidShow(() => {
     loadData(currentDate);
-    loadUser();
+    loadUserSettings();
   });
 
   const handlePrevDate = () => {
@@ -139,19 +142,20 @@ export default function Index() {
   };
 
   const handleProfileSave = (data: { nickname: string; avatar?: string }) => {
-    setUser((prev) => (prev ? { ...prev, ...data } : prev));
+    setUserSettings((prev) => (prev ? { ...prev, ...data } : prev));
     setShowProfilePopup(false);
   };
 
-  const displayNickname = user?.nickname || (user?._id ? getDefaultNickname(user._id) : "");
+  const displayNickname =
+    userSettings?.nickname || (userSettings?.userId ? getDefaultNickname(userSettings.userId) : "");
 
   return (
     <View className="overview-page">
       {/* 顶部栏：头像 + 日期选择器 */}
       <View className="top-header">
         <View className="header-avatar" onClick={handleAvatarClick}>
-          {user?.avatar ? (
-            <Image className="avatar-img" src={user.avatar} mode="aspectFill" />
+          {userSettings?.avatar ? (
+            <Image className="avatar-img" src={userSettings.avatar} mode="aspectFill" />
           ) : (
             <View className="avatar-default" />
           )}
@@ -174,7 +178,7 @@ export default function Index() {
       <ProfilePopup
         visible={showProfilePopup}
         nickname={displayNickname}
-        avatar={user?.avatar}
+        avatar={userSettings?.avatar}
         onClose={handleProfileClose}
         onSave={handleProfileSave}
       />

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,20 +1,23 @@
-import { View, Text, Picker } from "@tarojs/components";
+import { View, Text, Picker, Image } from "@tarojs/components";
 import Taro, { useDidShow } from "@tarojs/taro";
 import { useState, useCallback } from "react";
 import { getSymptomRecordsByDate } from "../../services/symptom";
 import { getMealRecordsByDate } from "../../services/meal";
 import { getStoolRecordsByDate } from "../../services/stool";
 import { getMedicationRecordsByDate } from "../../services/medication";
+import { getCurrentUser, getDefaultNickname } from "../../services/user";
 import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
 import { SYMPTOM_TYPES, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
 import { AMOUNT_OPTIONS } from "../../constants/meal";
 import { BRISTOL_TYPES, STOOL_AMOUNTS } from "../../constants/stool";
+import ProfilePopup from "../../components/ProfilePopup";
 import type {
   SymptomRecord,
   MealRecord,
   StoolRecord,
   MedicationRecord,
   Symptom,
+  User,
 } from "../../types";
 import "./index.css";
 
@@ -63,6 +66,8 @@ export default function Index() {
   const [mealRecords, setMealRecords] = useState<MealRecord[]>([]);
   const [stoolRecords, setStoolRecords] = useState<StoolRecord[]>([]);
   const [medicationRecords, setMedicationRecords] = useState<MedicationRecord[]>([]);
+  const [user, setUser] = useState<User | null>(null);
+  const [showProfilePopup, setShowProfilePopup] = useState(false);
 
   const loadData = useCallback(async (date: string) => {
     setLoading(true);
@@ -85,8 +90,18 @@ export default function Index() {
     }
   }, []);
 
+  const loadUser = useCallback(async () => {
+    try {
+      const userData = await getCurrentUser();
+      setUser(userData);
+    } catch (error) {
+      console.error("加载用户信息失败:", error);
+    }
+  }, []);
+
   useDidShow(() => {
     loadData(currentDate);
+    loadUser();
   });
 
   const handlePrevDate = () => {
@@ -115,22 +130,54 @@ export default function Index() {
     Taro.navigateTo({ url: path });
   };
 
+  const handleAvatarClick = () => {
+    setShowProfilePopup(true);
+  };
+
+  const handleProfileClose = () => {
+    setShowProfilePopup(false);
+  };
+
+  const handleProfileSave = (data: { nickname: string; avatar?: string }) => {
+    setUser((prev) => (prev ? { ...prev, ...data } : prev));
+    setShowProfilePopup(false);
+  };
+
+  const displayNickname = user?.nickname || (user?._id ? getDefaultNickname(user._id) : "");
+
   return (
     <View className="overview-page">
-      {/* 日期选择器 */}
-      <View className="date-header">
-        <Text className="date-arrow" onClick={handlePrevDate}>
-          ◀
-        </Text>
-        <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
-          <Text className="date-text">
-            {currentDate} {getWeekday(currentDate)}
+      {/* 顶部栏：头像 + 日期选择器 */}
+      <View className="top-header">
+        <View className="header-avatar" onClick={handleAvatarClick}>
+          {user?.avatar ? (
+            <Image className="avatar-img" src={user.avatar} mode="aspectFill" />
+          ) : (
+            <View className="avatar-default" />
+          )}
+        </View>
+        <View className="date-selector">
+          <Text className="date-arrow" onClick={handlePrevDate}>
+            ◀
           </Text>
-        </Picker>
-        <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
-          ▶
-        </Text>
+          <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
+            <Text className="date-text">
+              {currentDate} {getWeekday(currentDate)}
+            </Text>
+          </Picker>
+          <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
+            ▶
+          </Text>
+        </View>
       </View>
+
+      <ProfilePopup
+        visible={showProfilePopup}
+        nickname={displayNickname}
+        avatar={user?.avatar}
+        onClose={handleProfileClose}
+        onSave={handleProfileSave}
+      />
 
       {loading ? (
         <View className="loading">加载中...</View>

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -66,7 +66,7 @@ export default function Index() {
   const [stoolRecords, setStoolRecords] = useState<StoolRecord[]>([]);
   const [medicationRecords, setMedicationRecords] = useState<MedicationRecord[]>([]);
   const [userSettings, setUserSettings] = useState<{
-    userId: string;
+    _id: string;
     nickname?: string;
     avatar?: string;
   } | null>(null);
@@ -147,7 +147,7 @@ export default function Index() {
   };
 
   const displayNickname =
-    userSettings?.nickname || (userSettings?.userId ? getDefaultNickname(userSettings.userId) : "");
+    userSettings?.nickname || (userSettings?._id ? getDefaultNickname(userSettings._id) : "");
 
   return (
     <View className="overview-page">

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,0 +1,61 @@
+import Taro from "@tarojs/taro";
+import { getDatabase, getOpenId } from "../utils/cloud";
+import type { User } from "../types";
+
+const COLLECTION = "users";
+
+// 获取当前用户信息
+export async function getCurrentUser(): Promise<User> {
+  const db = getDatabase();
+  const openId = await getOpenId();
+
+  try {
+    const res = (await db.collection(COLLECTION).doc(openId).get()) as { data: User | null };
+
+    if (res.data) {
+      return res.data;
+    }
+  } catch {
+    // 用户不存在
+  }
+
+  // 用户不存在，返回默认值
+  return {
+    _id: openId,
+    createdAt: new Date(),
+  };
+}
+
+// 获取默认昵称
+export function getDefaultNickname(openId: string): string {
+  return `微信用户 ${openId.slice(-4)}`;
+}
+
+// 更新用户信息
+export async function updateUser(data: { nickname?: string; avatar?: string }): Promise<void> {
+  const db = getDatabase();
+  const openId = await getOpenId();
+
+  await db
+    .collection(COLLECTION)
+    .doc(openId)
+    .update({
+      data: {
+        ...data,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+// 上传头像到云存储
+export async function uploadAvatar(tempFilePath: string): Promise<string> {
+  const openId = await getOpenId();
+  const cloudPath = `${openId}/avatar.jpg`;
+
+  const res = await Taro.cloud.uploadFile({
+    cloudPath,
+    filePath: tempFilePath,
+  });
+
+  return res.fileID;
+}

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -31,20 +31,32 @@ export function getDefaultNickname(openId: string): string {
   return `微信用户 ${openId.slice(-4)}`;
 }
 
-// 更新用户信息
+// 更新用户信息（如果用户不存在则创建）
 export async function updateUser(data: { nickname?: string; avatar?: string }): Promise<void> {
   const db = getDatabase();
   const openId = await getOpenId();
 
-  await db
-    .collection(COLLECTION)
-    .doc(openId)
-    .update({
+  try {
+    // 先尝试更新
+    await db
+      .collection(COLLECTION)
+      .doc(openId)
+      .update({
+        data: {
+          ...data,
+          updatedAt: new Date(),
+        },
+      });
+  } catch {
+    // 用户不存在，创建新记录
+    await db.collection(COLLECTION).add({
       data: {
+        _id: openId,
         ...data,
-        updatedAt: new Date(),
+        createdAt: new Date(),
       },
     });
+  }
 }
 
 // 上传头像到云存储

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,57 +1,71 @@
 import Taro from "@tarojs/taro";
 import { getDatabase, getOpenId } from "../utils/cloud";
-import type { User } from "../types";
 
-const COLLECTION = "users";
+const COLLECTION = "user_settings";
 
-// 获取当前用户信息
-export async function getCurrentUser(): Promise<User> {
+interface UserSettings {
+  _id?: string;
+  userId: string;
+  nickname?: string;
+  avatar?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+// 获取当前用户设置
+export async function getUserSettings(): Promise<UserSettings> {
   const db = getDatabase();
-  const openId = await getOpenId();
+  const userId = await getOpenId();
 
   try {
-    const res = (await db.collection(COLLECTION).doc(openId).get()) as { data: User | null };
+    const res = await db.collection(COLLECTION).where({ userId }).limit(1).get();
 
-    if (res.data) {
-      return res.data;
+    if (res.data && res.data.length > 0) {
+      return res.data[0] as UserSettings;
     }
   } catch {
-    // 用户不存在
+    // 用户设置不存在
   }
 
-  // 用户不存在，返回默认值
+  // 返回默认值
   return {
-    _id: openId,
-    createdAt: new Date(),
+    userId,
   };
 }
 
 // 获取默认昵称
-export function getDefaultNickname(openId: string): string {
-  return `微信用户 ${openId.slice(-4)}`;
+export function getDefaultNickname(userId: string): string {
+  return `微信用户 ${userId.slice(-4)}`;
 }
 
-// 更新用户信息（如果用户不存在则创建）
-export async function updateUser(data: { nickname?: string; avatar?: string }): Promise<void> {
+// 更新用户设置（如果不存在则创建）
+export async function updateUserSettings(data: {
+  nickname?: string;
+  avatar?: string;
+}): Promise<void> {
   const db = getDatabase();
-  const openId = await getOpenId();
+  const userId = await getOpenId();
 
-  try {
-    // 先尝试更新
+  // 查找现有记录
+  const res = await db.collection(COLLECTION).where({ userId }).limit(1).get();
+
+  if (res.data && res.data.length > 0) {
+    // 更新现有记录
+    const doc = res.data[0] as UserSettings;
     await db
       .collection(COLLECTION)
-      .doc(openId)
+      .doc(doc._id!)
       .update({
         data: {
           ...data,
           updatedAt: new Date(),
         },
       });
-  } catch {
-    // 用户不存在，创建新记录
+  } else {
+    // 创建新记录
     await db.collection(COLLECTION).add({
       data: {
-        _id: openId,
+        userId,
         ...data,
         createdAt: new Date(),
       },

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -11,26 +11,29 @@ interface UserSettings {
   updatedAt?: Date;
 }
 
-// 获取当前用户设置
+// 获取当前用户设置（不存在则自动创建）
 export async function getUserSettings(): Promise<UserSettings> {
   const db = getDatabase();
   const userId = await getOpenId();
 
-  try {
-    const res = (await db.collection(COLLECTION).doc(userId).get()) as { data: UserSettings | null };
+  // 先查询是否存在
+  const res = await db.collection(COLLECTION).where({ _id: userId }).limit(1).get();
 
-    if (res.data) {
-      return res.data;
-    }
-  } catch (error) {
-    // 用户设置不存在，这是正常情况
-    console.debug("用户设置不存在，使用默认值");
+  if (res.data && res.data.length > 0) {
+    return res.data[0] as UserSettings;
   }
 
-  // 返回默认值
-  return {
+  // 不存在，创建新记录
+  const newSettings: UserSettings = {
     _id: userId,
+    createdAt: new Date(),
   };
+
+  await db.collection(COLLECTION).add({
+    data: newSettings,
+  });
+
+  return newSettings;
 }
 
 // 获取默认昵称
@@ -38,7 +41,7 @@ export function getDefaultNickname(userId: string): string {
   return `微信用户 ${userId.slice(-4)}`;
 }
 
-// 更新用户设置（使用 set 实现 upsert）
+// 更新用户设置
 export async function updateUserSettings(data: {
   nickname?: string;
   avatar?: string;
@@ -46,27 +49,15 @@ export async function updateUserSettings(data: {
   const db = getDatabase();
   const userId = await getOpenId();
 
-  // 先尝试更新
-  try {
-    await db
-      .collection(COLLECTION)
-      .doc(userId)
-      .update({
-        data: {
-          ...data,
-          updatedAt: new Date(),
-        },
-      });
-  } catch {
-    // 记录不存在，创建新记录（指定 _id 为 userId）
-    await db.collection(COLLECTION).add({
+  await db
+    .collection(COLLECTION)
+    .doc(userId)
+    .update({
       data: {
-        _id: userId,
         ...data,
-        createdAt: new Date(),
+        updatedAt: new Date(),
       },
     });
-  }
 }
 
 // 上传头像到云存储

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -22,8 +22,9 @@ export async function getUserSettings(): Promise<UserSettings> {
     if (res.data) {
       return res.data;
     }
-  } catch {
-    // 用户设置不存在
+  } catch (error) {
+    // 用户设置不存在，这是正常情况
+    console.debug("用户设置不存在，使用默认值");
   }
 
   // 返回默认值

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -4,8 +4,7 @@ import { getDatabase, getOpenId } from "../utils/cloud";
 const COLLECTION = "user_settings";
 
 interface UserSettings {
-  _id?: string;
-  userId: string;
+  _id: string; // 使用 userId 作为 _id
   nickname?: string;
   avatar?: string;
   createdAt?: Date;
@@ -18,10 +17,10 @@ export async function getUserSettings(): Promise<UserSettings> {
   const userId = await getOpenId();
 
   try {
-    const res = await db.collection(COLLECTION).where({ userId }).limit(1).get();
+    const res = (await db.collection(COLLECTION).doc(userId).get()) as { data: UserSettings | null };
 
-    if (res.data && res.data.length > 0) {
-      return res.data[0] as UserSettings;
+    if (res.data) {
+      return res.data;
     }
   } catch {
     // 用户设置不存在
@@ -29,7 +28,7 @@ export async function getUserSettings(): Promise<UserSettings> {
 
   // 返回默认值
   return {
-    userId,
+    _id: userId,
   };
 }
 
@@ -38,7 +37,7 @@ export function getDefaultNickname(userId: string): string {
   return `微信用户 ${userId.slice(-4)}`;
 }
 
-// 更新用户设置（如果不存在则创建）
+// 更新用户设置（使用 set 实现 upsert）
 export async function updateUserSettings(data: {
   nickname?: string;
   avatar?: string;
@@ -46,26 +45,22 @@ export async function updateUserSettings(data: {
   const db = getDatabase();
   const userId = await getOpenId();
 
-  // 查找现有记录
-  const res = await db.collection(COLLECTION).where({ userId }).limit(1).get();
-
-  if (res.data && res.data.length > 0) {
-    // 更新现有记录
-    const doc = res.data[0] as UserSettings;
+  // 先尝试更新
+  try {
     await db
       .collection(COLLECTION)
-      .doc(doc._id!)
+      .doc(userId)
       .update({
         data: {
           ...data,
           updatedAt: new Date(),
         },
       });
-  } else {
-    // 创建新记录
+  } catch {
+    // 记录不存在，创建新记录（指定 _id 为 userId）
     await db.collection(COLLECTION).add({
       data: {
-        userId,
+        _id: userId,
         ...data,
         createdAt: new Date(),
       },


### PR DESCRIPTION
## Summary
- Add user service for login and profile management
- Add ProfilePopup component for editing avatar and nickname
- Show user avatar in homepage header (left of date selector)
- Avatar uploads to cloud storage at `{openid}/avatar.jpg`
- Default nickname: "微信用户 {openid后4位}"

Closes #10

## Test plan
- [ ] Open homepage, verify gray default avatar appears left of date
- [ ] Click avatar, verify profile popup opens
- [ ] Select avatar via chooseAvatar, verify preview updates
- [ ] Enter nickname, verify input works
- [ ] Save, verify toast shows and avatar/nickname persist after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)