### PR TITLE
chore(types): remove unused MedicalRecord interface

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,16 +62,3 @@ export interface MedicationRecord {
   note?: string;
   createdAt: Date;
 }
-
-// 医疗检查记录
-export interface MedicalRecord {
-  _id?: string;
-  userId: string;
-  date: string;
-  type: "blood" | "stool" | "colonoscopy" | "gastroscopy" | "ct" | "ultrasound" | "other";
-  hospital?: string;
-  result?: string;
-  images?: string[];
-  note?: string;
-  createdAt: Date;
-}


### PR DESCRIPTION
## Summary
- Removed `MedicalRecord` interface from `src/types/index.ts`
- This type had no corresponding services, pages, or constants - dead code

Closes #33

## Test plan
- [x] All integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)