### PR TITLE
feat: refactor page layout with TabBar navigation

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,6 +1,8 @@
 export default defineAppConfig({
   pages: [
     "pages/index/index",
+    "pages/records/index",
+    "pages/settings/index",
     "pages/symptom/index/index",
     "pages/symptom/add/index",
     "pages/meal/index/index",
@@ -15,6 +17,26 @@ export default defineAppConfig({
     navigationBarBackgroundColor: "#fff",
     navigationBarTitleText: "MyGut",
     navigationBarTextStyle: "black",
+  },
+  tabBar: {
+    color: "#999",
+    selectedColor: "#07c160",
+    backgroundColor: "#fff",
+    borderStyle: "black",
+    list: [
+      {
+        pagePath: "pages/index/index",
+        text: "🏠 首页",
+      },
+      {
+        pagePath: "pages/records/index",
+        text: "📋 记录",
+      },
+      {
+        pagePath: "pages/settings/index",
+        text: "⚙️ 设置",
+      },
+    ],
   },
   cloud: true,
 });

--- a/src/pages/index/index.css
+++ b/src/pages/index/index.css
@@ -7,10 +7,16 @@
 /* 顶部栏 */
 .top-header {
   display: flex;
+  justify-content: space-between;
   align-items: center;
   padding: 24px 32px;
   background-color: #fff;
-  gap: 24px;
+}
+
+.app-title {
+  font-size: 40px;
+  font-weight: 700;
+  color: #07c160;
 }
 
 .header-avatar {
@@ -37,7 +43,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  flex: 1;
+  padding: 20px 32px;
+  background-color: #fff;
+  border-top: 1px solid #f0f0f0;
   gap: 24px;
 }
 

--- a/src/pages/index/index.css
+++ b/src/pages/index/index.css
@@ -1,7 +1,6 @@
-.overview-page {
+.home-page {
   min-height: 100vh;
   background-color: #f5f5f5;
-  padding-bottom: 40px;
 }
 
 /* 顶部栏 */
@@ -9,20 +8,31 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 24px 32px;
+  padding: 40px 32px;
   background-color: #fff;
 }
 
+.title-section {
+  display: flex;
+  flex-direction: column;
+}
+
 .app-title {
-  font-size: 40px;
+  font-size: 56px;
   font-weight: 700;
   color: #07c160;
+  margin-bottom: 8px;
+}
+
+.app-subtitle {
+  font-size: 28px;
+  color: #666;
 }
 
 .header-avatar {
-  width: 72px;
-  height: 72px;
-  border-radius: 36px;
+  width: 96px;
+  height: 96px;
+  border-radius: 48px;
   overflow: hidden;
   flex-shrink: 0;
 }
@@ -38,127 +48,43 @@
   background-color: #e0e0e0;
 }
 
-/* 日期选择器 */
-.date-selector {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 20px 32px;
-  background-color: #fff;
-  border-top: 1px solid #f0f0f0;
+/* 快速操作 */
+.quick-actions {
+  padding: 40px 32px;
+}
+
+.section-title {
+  font-size: 32px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 32px;
+  display: block;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 24px;
 }
 
-.date-arrow {
-  font-size: 36px;
-  color: #07c160;
-  padding: 16px;
-}
-
-.date-arrow.disabled {
-  color: #ccc;
-}
-
-.date-text {
-  font-size: 36px;
-  font-weight: 600;
-  color: #333;
-}
-
-/* 加载状态 */
-.loading {
+.action-item {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
-  padding: 80px;
-  color: #999;
-  font-size: 28px;
-}
-
-/* 记录容器 */
-.records-container {
-  padding: 0 24px;
-}
-
-/* 记录卡片 */
-.record-card {
+  justify-content: center;
+  padding: 48px 24px;
   background-color: #fff;
   border-radius: 16px;
-  margin-bottom: 20px;
-  overflow: hidden;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 5%);
 }
 
-.card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 24px 28px;
-  border-bottom: 1px solid #f0f0f0;
+.action-icon {
+  font-size: 56px;
+  margin-bottom: 16px;
 }
 
-.card-title-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.card-icon {
-  font-size: 36px;
-}
-
-.card-title {
+.action-label {
   font-size: 30px;
-  font-weight: 600;
   color: #333;
-}
-
-.card-count {
-  font-size: 24px;
-  color: #999;
-}
-
-.card-add-btn {
-  font-size: 40px;
-  color: #07c160;
-  padding: 8px 16px;
-}
-
-.card-content {
-  padding: 20px 28px;
-  min-height: 60px;
-}
-
-.empty-hint {
-  font-size: 26px;
-  color: #ccc;
-  text-align: center;
-  display: block;
-  padding: 20px 0;
-}
-
-.record-item {
-  display: flex;
-  align-items: center;
-  padding: 12px 0;
-  gap: 16px;
-}
-
-.record-time {
-  font-size: 26px;
-  color: #999;
-  min-width: 90px;
-}
-
-.record-feeling {
-  font-size: 28px;
-  margin-right: 8px;
-}
-
-.record-desc {
-  font-size: 28px;
-  color: #333;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-weight: 500;
 }

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -48,7 +48,7 @@ export default function Index() {
         <Text className="section-title">快速记录</Text>
         <View className="action-grid">
           <View className="action-item" onClick={() => handleNavigate("/pages/symptom/add/index")}>
-            <Text className="action-icon">🩺</Text>
+            <Text className="action-icon">🌡️</Text>
             <Text className="action-label">体感</Text>
           </View>
           <View className="action-item" onClick={() => handleNavigate("/pages/meal/add/index")}>

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,97 +1,15 @@
-import { View, Text, Picker, Image } from "@tarojs/components";
+import { View, Text, Image } from "@tarojs/components";
 import Taro, { useDidShow } from "@tarojs/taro";
 import { useState, useCallback } from "react";
-import { symptomService } from "../../services/symptom";
-import { mealService } from "../../services/meal";
-import { stoolService } from "../../services/stool";
-import { medicationService } from "../../services/medication";
-import { getUserSettings, getDefaultNickname } from "../../services/user";
-import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
-import { SYMPTOM_TYPES, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
-import { AMOUNT_OPTIONS } from "../../constants/meal";
-import { BRISTOL_TYPES, STOOL_AMOUNTS } from "../../constants/stool";
-import ProfilePopup from "../../components/ProfilePopup";
-import type {
-  SymptomRecord,
-  MealRecord,
-  StoolRecord,
-  MedicationRecord,
-  Symptom,
-} from "../../types";
+import { getUserSettings } from "../../services/user";
 import "./index.css";
 
-const getFeelingEmoji = (value: number): string => {
-  return FEELING_OPTIONS.find((f) => f.value === value)?.emoji || "😐";
-};
-
-const formatSymptom = (symptom: Symptom): string => {
-  const typeLabel = SYMPTOM_TYPES.find((t) => t.value === symptom.type)?.label || symptom.type;
-  const severityLabel = SEVERITY_OPTIONS.find((s) => s.value === symptom.severity)?.label || "";
-  return `${typeLabel}(${severityLabel})`;
-};
-
-const getAmountEmoji = (amount: number): string => {
-  return AMOUNT_OPTIONS.find((a) => a.value === amount)?.emoji || "🍚";
-};
-
-const getBristolEmoji = (type: number): string => {
-  return BRISTOL_TYPES.find((b) => b.value === type)?.emoji || "";
-};
-
-const getStoolAmountLabel = (amount: number): string => {
-  return STOOL_AMOUNTS.find((a) => a.value === amount)?.label || "";
-};
-
-const formatStoolAbnormal = (record: StoolRecord): string => {
-  const abnormals: string[] = [];
-  if (record.hasBlood) abnormals.push("带血");
-  if (record.hasMucus) abnormals.push("带粘液");
-  if (record.color !== "normal") {
-    const colorLabels: Record<string, string> = {
-      dark: "深色",
-      light: "浅色",
-      red: "带红",
-      black: "黑色",
-    };
-    abnormals.push(colorLabels[record.color] || "");
-  }
-  return abnormals.length > 0 ? abnormals.join("、") : "";
-};
-
 export default function Index() {
-  const [currentDate, setCurrentDate] = useState(formatDate());
-  const [loading, setLoading] = useState(true);
-  const [symptomRecords, setSymptomRecords] = useState<SymptomRecord[]>([]);
-  const [mealRecords, setMealRecords] = useState<MealRecord[]>([]);
-  const [stoolRecords, setStoolRecords] = useState<StoolRecord[]>([]);
-  const [medicationRecords, setMedicationRecords] = useState<MedicationRecord[]>([]);
   const [userSettings, setUserSettings] = useState<{
     _id: string;
     nickname?: string;
     avatar?: string;
   } | null>(null);
-  const [showProfilePopup, setShowProfilePopup] = useState(false);
-
-  const loadData = useCallback(async (date: string) => {
-    setLoading(true);
-    try {
-      const [symptoms, meals, stools, medications] = await Promise.all([
-        symptomService.getByDate(date),
-        mealService.getByDate(date),
-        stoolService.getByDate(date),
-        medicationService.getByDate(date),
-      ]);
-      setSymptomRecords(symptoms);
-      setMealRecords(meals);
-      setStoolRecords(stools);
-      setMedicationRecords(medications);
-    } catch (error) {
-      console.error("加载数据失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
-    } finally {
-      setLoading(false);
-    }
-  }, []);
 
   const loadUserSettings = useCallback(async () => {
     try {
@@ -103,58 +21,21 @@ export default function Index() {
   }, []);
 
   useDidShow(() => {
-    loadData(currentDate);
     loadUserSettings();
   });
-
-  const handlePrevDate = () => {
-    const newDate = getPrevDate(currentDate);
-    setCurrentDate(newDate);
-    loadData(newDate);
-  };
-
-  const today = formatDate();
-  const isToday = currentDate === today;
-
-  const handleNextDate = () => {
-    if (isToday) return;
-    const newDate = getNextDate(currentDate);
-    setCurrentDate(newDate);
-    loadData(newDate);
-  };
-
-  const handleDateChange = (e: { detail: { value: string } }) => {
-    const newDate = e.detail.value;
-    setCurrentDate(newDate);
-    loadData(newDate);
-  };
 
   const handleNavigate = (path: string) => {
     Taro.navigateTo({ url: path });
   };
 
-  const handleAvatarClick = () => {
-    setShowProfilePopup(true);
-  };
-
-  const handleProfileClose = () => {
-    setShowProfilePopup(false);
-  };
-
-  const handleProfileSave = (data: { nickname: string; avatar?: string }) => {
-    setUserSettings((prev) => (prev ? { ...prev, ...data } : prev));
-    setShowProfilePopup(false);
-  };
-
-  const displayNickname =
-    userSettings?.nickname || (userSettings?._id ? getDefaultNickname(userSettings._id) : "");
-
   return (
-    <View className="overview-page">
-      {/* 顶部栏：App 名称 + 头像 */}
+    <View className="home-page">
       <View className="top-header">
-        <Text className="app-title">MyGut</Text>
-        <View className="header-avatar" onClick={handleAvatarClick}>
+        <View className="title-section">
+          <Text className="app-title">MyGut</Text>
+          <Text className="app-subtitle">肠道健康记录</Text>
+        </View>
+        <View className="header-avatar">
           {userSettings?.avatar ? (
             <Image className="avatar-img" src={userSettings.avatar} mode="aspectFill" />
           ) : (
@@ -163,178 +44,30 @@ export default function Index() {
         </View>
       </View>
 
-      {/* 日期选择器 */}
-      <View className="date-selector">
-        <Text className="date-arrow" onClick={handlePrevDate}>
-          ◀
-        </Text>
-        <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
-          <Text className="date-text">
-            {currentDate} {getWeekday(currentDate)}
-          </Text>
-        </Picker>
-        <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
-          ▶
-        </Text>
-      </View>
-
-      <ProfilePopup
-        visible={showProfilePopup}
-        nickname={displayNickname}
-        avatar={userSettings?.avatar}
-        onClose={handleProfileClose}
-        onSave={handleProfileSave}
-      />
-
-      {loading ? (
-        <View className="loading">加载中...</View>
-      ) : (
-        <View className="records-container">
-          {/* 身体状态 */}
-          <View className="record-card">
-            <View className="card-header">
-              <View className="card-title-row">
-                <Text className="card-icon">🩺</Text>
-                <Text className="card-title">身体状态</Text>
-                <Text className="card-count">[{symptomRecords.length}条]</Text>
-              </View>
-              <Text
-                className="card-add-btn"
-                onClick={() => handleNavigate("/pages/symptom/add/index")}
-              >
-                ＋
-              </Text>
-            </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/symptom/index/index")}
-            >
-              {symptomRecords.length === 0 ? (
-                <Text className="empty-hint">暂无记录</Text>
-              ) : (
-                symptomRecords.slice(0, 3).map((record) => (
-                  <View key={record._id} className="record-item">
-                    <Text className="record-time">{record.time || "--:--"}</Text>
-                    <Text className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</Text>
-                    {record.symptoms.length > 0 && (
-                      <Text className="record-desc">
-                        {record.symptoms.map(formatSymptom).join("、")}
-                      </Text>
-                    )}
-                  </View>
-                ))
-              )}
-            </View>
+      <View className="quick-actions">
+        <Text className="section-title">快速记录</Text>
+        <View className="action-grid">
+          <View className="action-item" onClick={() => handleNavigate("/pages/symptom/add/index")}>
+            <Text className="action-icon">🩺</Text>
+            <Text className="action-label">体感</Text>
           </View>
-
-          {/* 用药记录 */}
-          <View className="record-card">
-            <View className="card-header">
-              <View className="card-title-row">
-                <Text className="card-icon">💊</Text>
-                <Text className="card-title">用药</Text>
-                <Text className="card-count">[{medicationRecords.length}条]</Text>
-              </View>
-              <Text
-                className="card-add-btn"
-                onClick={() => handleNavigate("/pages/medication/add/index")}
-              >
-                ＋
-              </Text>
-            </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/medication/index/index")}
-            >
-              {medicationRecords.length === 0 ? (
-                <Text className="empty-hint">暂无记录</Text>
-              ) : (
-                medicationRecords.slice(0, 3).map((record) => (
-                  <View key={record._id} className="record-item">
-                    <Text className="record-time">{record.time}</Text>
-                    <Text className="record-desc">
-                      {record.name}
-                      {record.dosage ? ` ${record.dosage}` : ""}
-                    </Text>
-                  </View>
-                ))
-              )}
-            </View>
+          <View className="action-item" onClick={() => handleNavigate("/pages/meal/add/index")}>
+            <Text className="action-icon">🍱</Text>
+            <Text className="action-label">饮食</Text>
           </View>
-
-          {/* 饮食记录 */}
-          <View className="record-card">
-            <View className="card-header">
-              <View className="card-title-row">
-                <Text className="card-icon">🍚</Text>
-                <Text className="card-title">饮食</Text>
-                <Text className="card-count">[{mealRecords.length}条]</Text>
-              </View>
-              <Text
-                className="card-add-btn"
-                onClick={() => handleNavigate("/pages/meal/add/index")}
-              >
-                ＋
-              </Text>
-            </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/meal/index/index")}
-            >
-              {mealRecords.length === 0 ? (
-                <Text className="empty-hint">暂无记录</Text>
-              ) : (
-                mealRecords.slice(0, 3).map((record) => (
-                  <View key={record._id} className="record-item">
-                    <Text className="record-time">{record.time}</Text>
-                    <Text className="record-feeling">{getAmountEmoji(record.amount)}</Text>
-                    <Text className="record-desc">{record.foods.join("、")}</Text>
-                  </View>
-                ))
-              )}
-            </View>
+          <View className="action-item" onClick={() => handleNavigate("/pages/stool/add/index")}>
+            <Text className="action-icon">💩</Text>
+            <Text className="action-label">排便</Text>
           </View>
-
-          {/* 排便记录 */}
-          <View className="record-card">
-            <View className="card-header">
-              <View className="card-title-row">
-                <Text className="card-icon">🚽</Text>
-                <Text className="card-title">排便</Text>
-                <Text className="card-count">[{stoolRecords.length}条]</Text>
-              </View>
-              <Text
-                className="card-add-btn"
-                onClick={() => handleNavigate("/pages/stool/add/index")}
-              >
-                ＋
-              </Text>
-            </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/stool/index/index")}
-            >
-              {stoolRecords.length === 0 ? (
-                <Text className="empty-hint">暂无记录</Text>
-              ) : (
-                stoolRecords.slice(0, 3).map((record) => {
-                  const abnormal = formatStoolAbnormal(record);
-                  return (
-                    <View key={record._id} className="record-item">
-                      <Text className="record-time">{record.time}</Text>
-                      <Text className="record-feeling">{getBristolEmoji(record.type)}</Text>
-                      <Text className="record-desc">
-                        {getStoolAmountLabel(record.amount)}
-                        {abnormal && ` · ${abnormal}`}
-                      </Text>
-                    </View>
-                  );
-                })
-              )}
-            </View>
+          <View
+            className="action-item"
+            onClick={() => handleNavigate("/pages/medication/add/index")}
+          >
+            <Text className="action-icon">💊</Text>
+            <Text className="action-label">用药</Text>
           </View>
         </View>
-      )}
+      </View>
     </View>
   );
 }

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -151,8 +151,9 @@ export default function Index() {
 
   return (
     <View className="overview-page">
-      {/* 顶部栏：头像 + 日期选择器 */}
+      {/* 顶部栏：App 名称 + 头像 */}
       <View className="top-header">
+        <Text className="app-title">MyGut</Text>
         <View className="header-avatar" onClick={handleAvatarClick}>
           {userSettings?.avatar ? (
             <Image className="avatar-img" src={userSettings.avatar} mode="aspectFill" />
@@ -160,19 +161,21 @@ export default function Index() {
             <View className="avatar-default" />
           )}
         </View>
-        <View className="date-selector">
-          <Text className="date-arrow" onClick={handlePrevDate}>
-            ◀
+      </View>
+
+      {/* 日期选择器 */}
+      <View className="date-selector">
+        <Text className="date-arrow" onClick={handlePrevDate}>
+          ◀
+        </Text>
+        <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
+          <Text className="date-text">
+            {currentDate} {getWeekday(currentDate)}
           </Text>
-          <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
-            <Text className="date-text">
-              {currentDate} {getWeekday(currentDate)}
-            </Text>
-          </Picker>
-          <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
-            ▶
-          </Text>
-        </View>
+        </Picker>
+        <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
+          ▶
+        </Text>
       </View>
 
       <ProfilePopup

--- a/src/pages/meal/index/index.tsx
+++ b/src/pages/meal/index/index.tsx
@@ -68,7 +68,7 @@ export default function MealIndex() {
       ) : records.length === 0 ? (
         <View className="empty">
           <Text className="empty-text">暂无记录</Text>
-          <Text className="empty-hint">点击右上角添加饮食记录</Text>
+          <Text className="empty-hint">点击右上角添加记录</Text>
         </View>
       ) : (
         <View className="record-list">

--- a/src/pages/medication/index/index.tsx
+++ b/src/pages/medication/index/index.tsx
@@ -63,7 +63,7 @@ export default function MedicationIndex() {
       ) : records.length === 0 ? (
         <View className="empty">
           <Text className="empty-text">暂无记录</Text>
-          <Text className="empty-hint">点击右上角添加用药记录</Text>
+          <Text className="empty-hint">点击右上角添加记录</Text>
         </View>
       ) : (
         <View className="record-list">

--- a/src/pages/records/index.config.ts
+++ b/src/pages/records/index.config.ts
@@ -1,3 +1,3 @@
 export default definePageConfig({
-  navigationBarTitleText: "体感",
+  navigationBarTitleText: "记录",
 });

--- a/src/pages/records/index.css
+++ b/src/pages/records/index.css
@@ -1,0 +1,129 @@
+.records-page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+  padding-bottom: 40px;
+}
+
+/* 日期选择器 */
+.date-selector {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px 32px;
+  background-color: #fff;
+  gap: 24px;
+}
+
+.date-arrow {
+  font-size: 36px;
+  color: #07c160;
+  padding: 16px;
+}
+
+.date-arrow.disabled {
+  color: #ccc;
+}
+
+.date-text {
+  font-size: 36px;
+  font-weight: 600;
+  color: #333;
+}
+
+/* 加载状态 */
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 80px;
+  color: #999;
+  font-size: 28px;
+}
+
+/* 记录容器 */
+.records-container {
+  padding: 20px 24px;
+}
+
+/* 记录卡片 */
+.record-card {
+  background-color: #fff;
+  border-radius: 16px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 28px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.card-icon {
+  font-size: 36px;
+}
+
+.card-title {
+  font-size: 30px;
+  font-weight: 600;
+  color: #333;
+}
+
+.card-count {
+  font-size: 24px;
+  color: #999;
+}
+
+.card-add-btn {
+  font-size: 40px;
+  color: #07c160;
+  padding: 8px 16px;
+}
+
+.card-content {
+  padding: 20px 28px;
+  min-height: 60px;
+}
+
+.empty-hint {
+  font-size: 26px;
+  color: #ccc;
+  text-align: center;
+  display: block;
+  padding: 20px 0;
+}
+
+.record-item {
+  display: flex;
+  align-items: center;
+  padding: 12px 0;
+  gap: 16px;
+}
+
+.record-time {
+  font-size: 26px;
+  color: #999;
+  min-width: 90px;
+}
+
+.record-feeling {
+  font-size: 28px;
+  margin-right: 8px;
+}
+
+.record-desc {
+  font-size: 28px;
+  color: #333;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/pages/records/index.tsx
+++ b/src/pages/records/index.tsx
@@ -1,0 +1,286 @@
+import { View, Text, Picker } from "@tarojs/components";
+import Taro, { useDidShow } from "@tarojs/taro";
+import { useState, useCallback } from "react";
+import { symptomService } from "../../services/symptom";
+import { mealService } from "../../services/meal";
+import { stoolService } from "../../services/stool";
+import { medicationService } from "../../services/medication";
+import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
+import { SYMPTOM_TYPES, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
+import { AMOUNT_OPTIONS } from "../../constants/meal";
+import { BRISTOL_TYPES, STOOL_AMOUNTS } from "../../constants/stool";
+import type {
+  SymptomRecord,
+  MealRecord,
+  StoolRecord,
+  MedicationRecord,
+  Symptom,
+} from "../../types";
+import "./index.css";
+
+const getFeelingEmoji = (value: number): string => {
+  return FEELING_OPTIONS.find((f) => f.value === value)?.emoji || "😐";
+};
+
+const formatSymptom = (symptom: Symptom): string => {
+  const typeLabel = SYMPTOM_TYPES.find((t) => t.value === symptom.type)?.label || symptom.type;
+  const severityLabel = SEVERITY_OPTIONS.find((s) => s.value === symptom.severity)?.label || "";
+  return `${typeLabel}(${severityLabel})`;
+};
+
+const getAmountEmoji = (amount: number): string => {
+  return AMOUNT_OPTIONS.find((a) => a.value === amount)?.emoji || "🍚";
+};
+
+const getBristolEmoji = (type: number): string => {
+  return BRISTOL_TYPES.find((b) => b.value === type)?.emoji || "";
+};
+
+const getStoolAmountLabel = (amount: number): string => {
+  return STOOL_AMOUNTS.find((a) => a.value === amount)?.label || "";
+};
+
+const formatStoolAbnormal = (record: StoolRecord): string => {
+  const abnormals: string[] = [];
+  if (record.hasBlood) abnormals.push("带血");
+  if (record.hasMucus) abnormals.push("带粘液");
+  if (record.color !== "normal") {
+    const colorLabels: Record<string, string> = {
+      dark: "深色",
+      light: "浅色",
+      red: "带红",
+      black: "黑色",
+    };
+    abnormals.push(colorLabels[record.color] || "");
+  }
+  return abnormals.length > 0 ? abnormals.join("、") : "";
+};
+
+export default function Records() {
+  const [currentDate, setCurrentDate] = useState(formatDate());
+  const [loading, setLoading] = useState(true);
+  const [symptomRecords, setSymptomRecords] = useState<SymptomRecord[]>([]);
+  const [mealRecords, setMealRecords] = useState<MealRecord[]>([]);
+  const [stoolRecords, setStoolRecords] = useState<StoolRecord[]>([]);
+  const [medicationRecords, setMedicationRecords] = useState<MedicationRecord[]>([]);
+
+  const loadData = useCallback(async (date: string) => {
+    setLoading(true);
+    try {
+      const [symptoms, meals, stools, medications] = await Promise.all([
+        symptomService.getByDate(date),
+        mealService.getByDate(date),
+        stoolService.getByDate(date),
+        medicationService.getByDate(date),
+      ]);
+      setSymptomRecords(symptoms);
+      setMealRecords(meals);
+      setStoolRecords(stools);
+      setMedicationRecords(medications);
+    } catch (error) {
+      console.error("加载数据失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useDidShow(() => {
+    loadData(currentDate);
+  });
+
+  const handlePrevDate = () => {
+    const newDate = getPrevDate(currentDate);
+    setCurrentDate(newDate);
+    loadData(newDate);
+  };
+
+  const today = formatDate();
+  const isToday = currentDate === today;
+
+  const handleNextDate = () => {
+    if (isToday) return;
+    const newDate = getNextDate(currentDate);
+    setCurrentDate(newDate);
+    loadData(newDate);
+  };
+
+  const handleDateChange = (e: { detail: { value: string } }) => {
+    const newDate = e.detail.value;
+    setCurrentDate(newDate);
+    loadData(newDate);
+  };
+
+  const handleNavigate = (path: string) => {
+    Taro.navigateTo({ url: path });
+  };
+
+  return (
+    <View className="records-page">
+      {/* 日期选择器 */}
+      <View className="date-selector">
+        <Text className="date-arrow" onClick={handlePrevDate}>
+          ◀
+        </Text>
+        <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
+          <Text className="date-text">
+            {currentDate} {getWeekday(currentDate)}
+          </Text>
+        </Picker>
+        <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
+          ▶
+        </Text>
+      </View>
+
+      {loading ? (
+        <View className="loading">加载中...</View>
+      ) : (
+        <View className="records-container">
+          {/* 体感 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">🩺</Text>
+                <Text className="card-title">体感</Text>
+                <Text className="card-count">[{symptomRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/symptom/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/symptom/index/index")}
+            >
+              {symptomRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                symptomRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time || "--:--"}</Text>
+                    <Text className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</Text>
+                    {record.symptoms.length > 0 && (
+                      <Text className="record-desc">
+                        {record.symptoms.map(formatSymptom).join("、")}
+                      </Text>
+                    )}
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+
+          {/* 用药记录 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">💊</Text>
+                <Text className="card-title">用药</Text>
+                <Text className="card-count">[{medicationRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/medication/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/medication/index/index")}
+            >
+              {medicationRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                medicationRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time}</Text>
+                    <Text className="record-desc">
+                      {record.name}
+                      {record.dosage ? ` ${record.dosage}` : ""}
+                    </Text>
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+
+          {/* 饮食记录 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">🍱</Text>
+                <Text className="card-title">饮食</Text>
+                <Text className="card-count">[{mealRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/meal/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/meal/index/index")}
+            >
+              {mealRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                mealRecords.slice(0, 3).map((record) => (
+                  <View key={record._id} className="record-item">
+                    <Text className="record-time">{record.time}</Text>
+                    <Text className="record-feeling">{getAmountEmoji(record.amount)}</Text>
+                    <Text className="record-desc">{record.foods.join("、")}</Text>
+                  </View>
+                ))
+              )}
+            </View>
+          </View>
+
+          {/* 排便记录 */}
+          <View className="record-card">
+            <View className="card-header">
+              <View className="card-title-row">
+                <Text className="card-icon">💩</Text>
+                <Text className="card-title">排便</Text>
+                <Text className="card-count">[{stoolRecords.length}条]</Text>
+              </View>
+              <Text
+                className="card-add-btn"
+                onClick={() => handleNavigate("/pages/stool/add/index")}
+              >
+                ＋
+              </Text>
+            </View>
+            <View
+              className="card-content"
+              onClick={() => handleNavigate("/pages/stool/index/index")}
+            >
+              {stoolRecords.length === 0 ? (
+                <Text className="empty-hint">暂无记录</Text>
+              ) : (
+                stoolRecords.slice(0, 3).map((record) => {
+                  const abnormal = formatStoolAbnormal(record);
+                  return (
+                    <View key={record._id} className="record-item">
+                      <Text className="record-time">{record.time}</Text>
+                      <Text className="record-feeling">{getBristolEmoji(record.type)}</Text>
+                      <Text className="record-desc">
+                        {getStoolAmountLabel(record.amount)}
+                        {abnormal && ` · ${abnormal}`}
+                      </Text>
+                    </View>
+                  );
+                })
+              )}
+            </View>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/pages/records/index.tsx
+++ b/src/pages/records/index.tsx
@@ -140,7 +140,7 @@ export default function Records() {
           <View className="record-card">
             <View className="card-header">
               <View className="card-title-row">
-                <Text className="card-icon">🩺</Text>
+                <Text className="card-icon">🌡️</Text>
                 <Text className="card-title">体感</Text>
                 <Text className="card-count">[{symptomRecords.length}条]</Text>
               </View>

--- a/src/pages/settings/index.config.ts
+++ b/src/pages/settings/index.config.ts
@@ -1,3 +1,3 @@
 export default definePageConfig({
-  navigationBarTitleText: "体感",
+  navigationBarTitleText: "设置",
 });

--- a/src/pages/settings/index.css
+++ b/src/pages/settings/index.css
@@ -1,0 +1,55 @@
+.settings-page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+}
+
+/* 个人资料 */
+.profile-section {
+  display: flex;
+  align-items: center;
+  padding: 32px;
+  background-color: #fff;
+  margin-bottom: 20px;
+}
+
+.profile-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 60px;
+  overflow: hidden;
+  flex-shrink: 0;
+  margin-right: 32px;
+}
+
+.avatar-img {
+  width: 100%;
+  height: 100%;
+}
+
+.avatar-default {
+  width: 100%;
+  height: 100%;
+  background-color: #e0e0e0;
+}
+
+.profile-info {
+  flex: 1;
+}
+
+.profile-nickname {
+  font-size: 36px;
+  font-weight: 600;
+  color: #333;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.profile-hint {
+  font-size: 26px;
+  color: #999;
+}
+
+.profile-arrow {
+  font-size: 40px;
+  color: #ccc;
+}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,0 +1,72 @@
+import { View, Text, Image } from "@tarojs/components";
+import { useDidShow } from "@tarojs/taro";
+import { useState, useCallback } from "react";
+import { getUserSettings, getDefaultNickname } from "../../services/user";
+import ProfilePopup from "../../components/ProfilePopup";
+import "./index.css";
+
+export default function Settings() {
+  const [userSettings, setUserSettings] = useState<{
+    _id: string;
+    nickname?: string;
+    avatar?: string;
+  } | null>(null);
+  const [showProfilePopup, setShowProfilePopup] = useState(false);
+
+  const loadUserSettings = useCallback(async () => {
+    try {
+      const settings = await getUserSettings();
+      setUserSettings(settings);
+    } catch (error) {
+      console.error("加载用户设置失败:", error);
+    }
+  }, []);
+
+  useDidShow(() => {
+    loadUserSettings();
+  });
+
+  const handleProfileClick = () => {
+    setShowProfilePopup(true);
+  };
+
+  const handleProfileClose = () => {
+    setShowProfilePopup(false);
+  };
+
+  const handleProfileSave = (data: { nickname: string; avatar?: string }) => {
+    setUserSettings((prev) => (prev ? { ...prev, ...data } : prev));
+    setShowProfilePopup(false);
+  };
+
+  const displayNickname =
+    userSettings?.nickname ||
+    (userSettings?._id ? getDefaultNickname(userSettings._id) : "加载中...");
+
+  return (
+    <View className="settings-page">
+      <View className="profile-section" onClick={handleProfileClick}>
+        <View className="profile-avatar">
+          {userSettings?.avatar ? (
+            <Image className="avatar-img" src={userSettings.avatar} mode="aspectFill" />
+          ) : (
+            <View className="avatar-default" />
+          )}
+        </View>
+        <View className="profile-info">
+          <Text className="profile-nickname">{displayNickname}</Text>
+          <Text className="profile-hint">点击编辑个人资料</Text>
+        </View>
+        <Text className="profile-arrow">›</Text>
+      </View>
+
+      <ProfilePopup
+        visible={showProfilePopup}
+        nickname={displayNickname}
+        avatar={userSettings?.avatar}
+        onClose={handleProfileClose}
+        onSave={handleProfileSave}
+      />
+    </View>
+  );
+}

--- a/src/pages/stool/index/index.tsx
+++ b/src/pages/stool/index/index.tsx
@@ -76,7 +76,7 @@ export default function StoolIndex() {
       ) : records.length === 0 ? (
         <View className="empty">
           <Text className="empty-text">暂无记录</Text>
-          <Text className="empty-hint">点击右上角添加排便记录</Text>
+          <Text className="empty-hint">点击右上角添加记录</Text>
         </View>
       ) : (
         <View className="record-list">

--- a/src/pages/symptom/add/index.config.ts
+++ b/src/pages/symptom/add/index.config.ts
@@ -1,3 +1,3 @@
 export default definePageConfig({
-  navigationBarTitleText: "记录身体状态",
+  navigationBarTitleText: "记录体感",
 });

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -125,7 +125,7 @@ export default function SymptomAdd() {
 
         {symptoms.length === 0 ? (
           <View className="empty-symptoms">
-            <Text className="empty-text">无症状，身体状态良好</Text>
+            <Text className="empty-text">无症状</Text>
           </View>
         ) : (
           <View className="symptom-list">

--- a/src/pages/symptom/index/index.tsx
+++ b/src/pages/symptom/index/index.tsx
@@ -65,7 +65,7 @@ export default function SymptomIndex() {
   return (
     <View className="health-page">
       <View className="header">
-        <Text className="title">身体状态记录</Text>
+        <Text className="title">体感记录</Text>
         <View className="add-btn" onClick={handleAdd}>
           + 添加
         </View>
@@ -76,7 +76,7 @@ export default function SymptomIndex() {
       ) : records.length === 0 ? (
         <View className="empty">
           <Text className="empty-text">暂无记录</Text>
-          <Text className="empty-hint">点击右上角添加身体状态</Text>
+          <Text className="empty-hint">点击右上角添加记录</Text>
         </View>
       ) : (
         <View className="record-list">


### PR DESCRIPTION
## Summary

- 新增 TabBar 导航：首页、记录、设置三个标签页
- 首页：展示 app 标题和用户头像，提供快速记录入口（体感、饮食、排便、用药）
- 记录页：按日期查看所有记录类型
- 设置页：用户头像和昵称编辑
- 统一图标和标签命名

布局：
```
┌─────────────────────────────┐
│ MyGut              👤      │  <- 首页顶栏
│ 肠道健康记录                │
├─────────────────────────────┤
│  🌡️    🍱    💩    💊      │  <- 快速记录
│ 体感  饮食  排便  用药      │
├─────────────────────────────┤
│ 🏠首页  📋记录  ⚙️设置     │  <- TabBar
└─────────────────────────────┘
```

Changes:
- 新增 `src/pages/records/index.tsx` - 记录页（原首页功能）
- 新增 `src/pages/settings/index.tsx` - 设置页
- 重构 `src/pages/index/index.tsx` - 新首页
- 更新 `src/app.config.ts` - TabBar 配置
- 图标更新：体感 🌡️、饮食 🍱、排便 💩
- 标签更新："身体状态" → "体感"

Closes #37

## Test plan

- [ ] TabBar 三个标签页切换正常
- [ ] 首页快速记录按钮跳转正确
- [ ] 记录页日期选择和数据加载正常
- [ ] 设置页头像和昵称编辑功能正常

🤖 Generated with [Claude Code](https://claude.ai/claude-code)