### PR TITLE
feat(services): implement soft delete for records

### DIFF
--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -5,6 +5,7 @@ interface BaseRecord {
   userId: string;
   date: string;
   createdAt: Date;
+  deletedAt?: Date;
 }
 
 export function createRecordService<T extends BaseRecord>(collection: string) {
@@ -21,9 +22,13 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
     async getRecent(limit = 20): Promise<T[]> {
       const db = getDatabase();
       const userId = await getOpenId();
+      const _ = db.command;
       const res = await db
         .collection(collection)
-        .where({ userId })
+        .where({
+          userId,
+          deletedAt: _.exists(false),
+        })
         .orderBy("createdAt", "desc")
         .limit(limit)
         .get();
@@ -32,15 +37,25 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
 
     async delete(id: string): Promise<void> {
       const db = getDatabase();
-      await db.collection(collection).doc(id).remove();
+      await db
+        .collection(collection)
+        .doc(id)
+        .update({
+          data: { deletedAt: new Date() },
+        });
     },
 
     async getByDate(date: string): Promise<T[]> {
       const db = getDatabase();
       const userId = await getOpenId();
+      const _ = db.command;
       const res = await db
         .collection(collection)
-        .where({ userId, date })
+        .where({
+          userId,
+          date,
+          deletedAt: _.exists(false),
+        })
         .orderBy("time", "asc")
         .get();
       return res.data as T[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export interface SymptomRecord {
   overallFeeling: 1 | 2 | 3 | 4 | 5; // 整体感受 1很差 - 5很好
   note?: string;
   createdAt: Date;
+  deletedAt?: Date;
 }
 
 // 饮食记录
@@ -34,6 +35,7 @@ export interface MealRecord {
   amount: 1 | 2 | 3; // 1-少量 2-适中 3-大量
   note?: string;
   createdAt: Date;
+  deletedAt?: Date;
 }
 
 // 排便记录
@@ -49,6 +51,7 @@ export interface StoolRecord {
   hasMucus?: boolean;
   note?: string;
   createdAt: Date;
+  deletedAt?: Date;
 }
 
 // 用药记录
@@ -61,4 +64,5 @@ export interface MedicationRecord {
   dosage: string;
   note?: string;
   createdAt: Date;
+  deletedAt?: Date;
 }

--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -8,9 +8,23 @@ const E2E_TEST_USER_ID = "e2e_test_user";
 // 内存数据库存储
 const memoryStore: Map<string, Record<string, unknown>[]> = new Map();
 
+// 查询命令标记
+const EXISTS_FALSE = Symbol("exists_false");
+
+// 内存数据库命令
+const memoryCommand = {
+  exists(value: boolean) {
+    if (value === false) {
+      return EXISTS_FALSE;
+    }
+    return { __exists: value };
+  },
+};
+
 // 内存数据库实现
 function createMemoryDatabase() {
   return {
+    command: memoryCommand,
     collection(name: string) {
       if (!memoryStore.has(name)) {
         memoryStore.set(name, []);
@@ -43,7 +57,12 @@ function createMemoryCollection(data: Record<string, unknown>[]) {
     },
     async get() {
       let result = data.filter((item) => {
-        return Object.entries(filters).every(([key, value]) => item[key] === value);
+        return Object.entries(filters).every(([key, value]) => {
+          if (value === EXISTS_FALSE) {
+            return !(key in item) || item[key] === undefined || item[key] === null;
+          }
+          return item[key] === value;
+        });
       });
 
       if (sortField) {


### PR DESCRIPTION
## Summary
- Replace hard delete with soft delete by setting `deletedAt` timestamp
- Filter out deleted records in all query methods
- Add `deletedAt` field to all record types (SymptomRecord, MealRecord, StoolRecord, MedicationRecord)
- Add `command.exists()` support to in-memory database for testing

Closes #41

## Test plan
- [ ] Delete a record and verify it no longer appears in list
- [ ] Verify deleted records still exist in database with `deletedAt` set
- [ ] Run `pnpm test` to verify all integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)