### PR TITLE
feat: add edit mode and separate click targets (#51)

### DIFF
--- a/src/pages/meal/add/index.tsx
+++ b/src/pages/meal/add/index.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Input, Textarea, Picker } from "@tarojs/components";
-import Taro, { useDidShow } from "@tarojs/taro";
-import { useState } from "react";
+import Taro, { useDidShow, useRouter } from "@tarojs/taro";
+import { useState, useEffect } from "react";
 import { mealService } from "../../../services/meal";
 import { FOOD_CATEGORIES, AMOUNT_OPTIONS } from "../../../constants/meal";
 import { formatDate, formatTime } from "../../../utils/date";
@@ -39,6 +39,10 @@ function removeCustomFood(food: string) {
 }
 
 export default function MealAdd() {
+  const router = useRouter();
+  const editId = router.params.id;
+  const isEdit = !!editId;
+
   const [date, setDate] = useState(formatDate());
   const [time, setTime] = useState(formatTime());
   const [selectedCategory, setSelectedCategory] = useState(-1); // -1 = 我的常用
@@ -49,6 +53,31 @@ export default function MealAdd() {
   const [submitting, setSubmitting] = useState(false);
   const [customFoods, setCustomFoods] = useState<string[]>([]);
   const [topFoods, setTopFoods] = useState<string[]>([]);
+  const [loading, setLoading] = useState(isEdit);
+
+  useEffect(() => {
+    if (editId) {
+      loadRecord(editId);
+    }
+  }, [editId]);
+
+  const loadRecord = async (id: string) => {
+    try {
+      const record = await mealService.getById(id);
+      if (record) {
+        setDate(record.date);
+        setTime(record.time || formatTime());
+        setSelectedFoods(record.foods);
+        setAmount(record.amount);
+        setNote(record.note || "");
+      }
+    } catch (error) {
+      console.error("加载记录失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useDidShow(() => {
     setCustomFoods(getStoredCustomFoods());
@@ -100,6 +129,27 @@ export default function MealAdd() {
     setSelectedFoods(selectedFoods.filter((f) => f !== food));
   };
 
+  const handleDelete = async () => {
+    if (!editId) return;
+
+    const res = await Taro.showModal({
+      title: "确认删除",
+      content: "确定要删除这条记录吗？",
+    });
+
+    if (res.confirm) {
+      try {
+        await mealService.delete(editId);
+        Taro.showToast({ title: "已删除", icon: "success" });
+        setTimeout(() => {
+          Taro.navigateBack();
+        }, 1500);
+      } catch {
+        Taro.showToast({ title: "删除失败", icon: "none" });
+      }
+    }
+  };
+
   const handleSubmit = async () => {
     if (submitting) return;
 
@@ -110,15 +160,22 @@ export default function MealAdd() {
 
     setSubmitting(true);
     try {
-      await mealService.add({
+      const data = {
         date,
         time,
         foods: selectedFoods,
         amount,
         note: note.trim() || undefined,
-      });
+      };
 
-      Taro.showToast({ title: "记录成功", icon: "success" });
+      if (isEdit && editId) {
+        await mealService.update(editId, data);
+        Taro.showToast({ title: "更新成功", icon: "success" });
+      } else {
+        await mealService.add(data);
+        Taro.showToast({ title: "记录成功", icon: "success" });
+      }
+
       setTimeout(() => {
         Taro.navigateBack();
       }, 1500);
@@ -138,6 +195,14 @@ export default function MealAdd() {
     selectedCategory === -1
       ? myFavoriteFoods.map((name) => ({ name, emoji: FOOD_EMOJI_MAP.get(name) }))
       : FOOD_CATEGORIES[selectedCategory].items;
+
+  if (loading) {
+    return (
+      <View className="add-page">
+        <View className="loading">加载中...</View>
+      </View>
+    );
+  }
 
   return (
     <View className="add-page">
@@ -265,8 +330,13 @@ export default function MealAdd() {
       {/* 提交按钮 */}
       <View className="submit-section">
         <View className={`submit-btn ${submitting ? "disabled" : ""}`} onClick={handleSubmit}>
-          {submitting ? "保存中..." : "保存记录"}
+          {submitting ? "保存中..." : isEdit ? "更新记录" : "保存记录"}
         </View>
+        {isEdit && (
+          <View className="delete-btn" onClick={handleDelete}>
+            删除记录
+          </View>
+        )}
       </View>
     </View>
   );

--- a/src/pages/meal/index/index.tsx
+++ b/src/pages/meal/index/index.tsx
@@ -32,22 +32,8 @@ export default function MealIndex() {
     Taro.navigateTo({ url: "/pages/meal/add/index" });
   };
 
-  const handleDelete = async (id: string) => {
-    const res = await Taro.showModal({
-      title: "确认删除",
-      content: "确定要删除这条记录吗？",
-    });
-
-    if (res.confirm) {
-      try {
-        const { mealService: svc } = await import("../../../services/meal");
-        await svc.delete(id);
-        Taro.showToast({ title: "已删除", icon: "success" });
-        loadRecords();
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
-      }
-    }
+  const handleEdit = (id: string) => {
+    Taro.navigateTo({ url: `/pages/meal/add/index?id=${id}` });
   };
 
   const getAmountInfo = (amount: 1 | 2 | 3) => {
@@ -75,7 +61,11 @@ export default function MealIndex() {
           {records.map((record) => {
             const amount = getAmountInfo(record.amount);
             return (
-              <View key={record._id} className="record-item">
+              <View
+                key={record._id}
+                className="record-item"
+                onClick={() => handleEdit(record._id!)}
+              >
                 <View className="record-main">
                   <View className="record-header">
                     <Text className="record-date">
@@ -96,9 +86,6 @@ export default function MealIndex() {
                   </View>
 
                   {record.note && <Text className="record-note">{record.note}</Text>}
-                </View>
-                <View className="delete-btn" onClick={() => handleDelete(record._id!)}>
-                  删除
                 </View>
               </View>
             );

--- a/src/pages/medication/add/index.tsx
+++ b/src/pages/medication/add/index.tsx
@@ -39,7 +39,7 @@ export default function MedicationAdd() {
   const [date, setDate] = useState(formatDate());
   const [time, setTime] = useState(formatTime());
   const [selectedCategory, setSelectedCategory] = useState(-1); // -1 = 常用
-  const [selectedMedications, setSelectedMedications] = useState<string[]>([]);
+  const [selectedMedication, setSelectedMedication] = useState("");
   const [manualInput, setManualInput] = useState("");
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -59,7 +59,7 @@ export default function MedicationAdd() {
       if (record) {
         setDate(record.date);
         setTime(record.time || formatTime());
-        setSelectedMedications([record.name]);
+        setSelectedMedication(record.name);
         setNote(record.note || "");
       }
     } catch (error) {
@@ -77,10 +77,11 @@ export default function MedicationAdd() {
   });
 
   const handleMedicationClick = (medication: string) => {
-    if (selectedMedications.includes(medication)) {
-      setSelectedMedications(selectedMedications.filter((m) => m !== medication));
+    // 单选：点击选中，再点击取消
+    if (selectedMedication === medication) {
+      setSelectedMedication("");
     } else {
-      setSelectedMedications([...selectedMedications, medication]);
+      setSelectedMedication(medication);
     }
   };
 
@@ -90,11 +91,7 @@ export default function MedicationAdd() {
       Taro.showToast({ title: "请输入药物名称", icon: "none" });
       return;
     }
-    if (selectedMedications.includes(medication)) {
-      Taro.showToast({ title: "已添加该药物", icon: "none" });
-      return;
-    }
-    setSelectedMedications([...selectedMedications, medication]);
+    setSelectedMedication(medication);
     setManualInput("");
     if (!ALL_PRESET_MEDICATIONS.has(medication)) {
       saveCustomMedication(medication);
@@ -110,12 +107,14 @@ export default function MedicationAdd() {
     if (res.confirm) {
       removeCustomMedication(medication);
       setCustomMedications(getStoredCustomMedications());
-      setSelectedMedications(selectedMedications.filter((m) => m !== medication));
+      if (selectedMedication === medication) {
+        setSelectedMedication("");
+      }
     }
   };
 
-  const handleRemoveMedication = (medication: string) => {
-    setSelectedMedications(selectedMedications.filter((m) => m !== medication));
+  const handleClearMedication = () => {
+    setSelectedMedication("");
   };
 
   const handleDelete = async () => {
@@ -142,32 +141,25 @@ export default function MedicationAdd() {
   const handleSubmit = async () => {
     if (submitting) return;
 
-    if (selectedMedications.length === 0) {
+    if (!selectedMedication) {
       Taro.showToast({ title: "请选择或输入药物", icon: "none" });
       return;
     }
 
     setSubmitting(true);
     try {
+      const data = {
+        date,
+        time,
+        name: selectedMedication,
+        note: note.trim() || undefined,
+      };
+
       if (isEdit && editId) {
-        // 编辑模式：更新单条记录
-        await medicationService.update(editId, {
-          date,
-          time,
-          name: selectedMedications[0],
-          note: note.trim() || undefined,
-        });
+        await medicationService.update(editId, data);
         Taro.showToast({ title: "更新成功", icon: "success" });
       } else {
-        // 新增模式：为每个选中的药物创建一条记录
-        for (const medication of selectedMedications) {
-          await medicationService.add({
-            date,
-            time,
-            name: medication,
-            note: note.trim() || undefined,
-          });
-        }
+        await medicationService.add(data);
         Taro.showToast({ title: "记录成功", icon: "success" });
       }
 
@@ -248,7 +240,7 @@ export default function MedicationAdd() {
               return (
                 <View
                   key={medication}
-                  className={`medication-item ${selectedMedications.includes(medication) ? "selected" : ""} ${isCustom ? "custom" : ""}`}
+                  className={`medication-item ${selectedMedication === medication ? "selected" : ""} ${isCustom ? "custom" : ""}`}
                   onClick={() => handleMedicationClick(medication)}
                   onLongPress={
                     isCustom ? () => handleDeleteCustomMedication(medication) : undefined
@@ -281,20 +273,14 @@ export default function MedicationAdd() {
       {/* 已选药物 */}
       <View className="section">
         <Text className="section-title">已选药物</Text>
-        {selectedMedications.length === 0 ? (
+        {!selectedMedication ? (
           <Text className="no-medication-hint">请从上方选择或输入药物</Text>
         ) : (
-          <View className="selected-medications">
-            {selectedMedications.map((medication) => (
-              <View
-                key={medication}
-                className="selected-medication-tag"
-                onClick={() => handleRemoveMedication(medication)}
-              >
-                <Text className="selected-medication-name">{medication}</Text>
-                <Text className="remove-medication-btn">×</Text>
-              </View>
-            ))}
+          <View className="selected-medication">
+            <Text className="selected-medication-name">{selectedMedication}</Text>
+            <Text className="clear-medication-btn" onClick={handleClearMedication}>
+              清除
+            </Text>
           </View>
         )}
       </View>

--- a/src/pages/medication/add/index.tsx
+++ b/src/pages/medication/add/index.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Input, Textarea, Picker } from "@tarojs/components";
-import Taro, { useDidShow } from "@tarojs/taro";
-import { useState } from "react";
+import Taro, { useDidShow, useRouter } from "@tarojs/taro";
+import { useState, useEffect } from "react";
 import { medicationService } from "../../../services/medication";
 import { MEDICATION_CATEGORIES } from "../../../constants/medication";
 import { formatDate, formatTime } from "../../../utils/date";
@@ -32,6 +32,10 @@ function removeCustomMedication(medication: string) {
 }
 
 export default function MedicationAdd() {
+  const router = useRouter();
+  const editId = router.params.id;
+  const isEdit = !!editId;
+
   const [date, setDate] = useState(formatDate());
   const [time, setTime] = useState(formatTime());
   const [selectedCategory, setSelectedCategory] = useState(-1); // -1 = 常用
@@ -41,6 +45,30 @@ export default function MedicationAdd() {
   const [submitting, setSubmitting] = useState(false);
   const [customMedications, setCustomMedications] = useState<string[]>([]);
   const [topMedications, setTopMedications] = useState<string[]>([]);
+  const [loading, setLoading] = useState(isEdit);
+
+  useEffect(() => {
+    if (editId) {
+      loadRecord(editId);
+    }
+  }, [editId]);
+
+  const loadRecord = async (id: string) => {
+    try {
+      const record = await medicationService.getById(id);
+      if (record) {
+        setDate(record.date);
+        setTime(record.time || formatTime());
+        setSelectedMedications([record.name]);
+        setNote(record.note || "");
+      }
+    } catch (error) {
+      console.error("加载记录失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useDidShow(() => {
     setCustomMedications(getStoredCustomMedications());
@@ -90,6 +118,27 @@ export default function MedicationAdd() {
     setSelectedMedications(selectedMedications.filter((m) => m !== medication));
   };
 
+  const handleDelete = async () => {
+    if (!editId) return;
+
+    const res = await Taro.showModal({
+      title: "确认删除",
+      content: "确定要删除这条记录吗？",
+    });
+
+    if (res.confirm) {
+      try {
+        await medicationService.delete(editId);
+        Taro.showToast({ title: "已删除", icon: "success" });
+        setTimeout(() => {
+          Taro.navigateBack();
+        }, 1500);
+      } catch {
+        Taro.showToast({ title: "删除失败", icon: "none" });
+      }
+    }
+  };
+
   const handleSubmit = async () => {
     if (submitting) return;
 
@@ -100,17 +149,28 @@ export default function MedicationAdd() {
 
     setSubmitting(true);
     try {
-      // 为每个选中的药物创建一条记录
-      for (const medication of selectedMedications) {
-        await medicationService.add({
+      if (isEdit && editId) {
+        // 编辑模式：更新单条记录
+        await medicationService.update(editId, {
           date,
           time,
-          name: medication,
+          name: selectedMedications[0],
           note: note.trim() || undefined,
         });
+        Taro.showToast({ title: "更新成功", icon: "success" });
+      } else {
+        // 新增模式：为每个选中的药物创建一条记录
+        for (const medication of selectedMedications) {
+          await medicationService.add({
+            date,
+            time,
+            name: medication,
+            note: note.trim() || undefined,
+          });
+        }
+        Taro.showToast({ title: "记录成功", icon: "success" });
       }
 
-      Taro.showToast({ title: "记录成功", icon: "success" });
       setTimeout(() => {
         Taro.navigateBack();
       }, 1500);
@@ -131,6 +191,14 @@ export default function MedicationAdd() {
   // 当前分类的药品列表
   const currentMedications =
     selectedCategory === -1 ? myFavoriteMedications : MEDICATION_CATEGORIES[selectedCategory].items;
+
+  if (loading) {
+    return (
+      <View className="add-page">
+        <View className="loading">加载中...</View>
+      </View>
+    );
+  }
 
   return (
     <View className="add-page">
@@ -246,8 +314,13 @@ export default function MedicationAdd() {
       {/* 提交按钮 */}
       <View className="submit-section">
         <View className={`submit-btn ${submitting ? "disabled" : ""}`} onClick={handleSubmit}>
-          {submitting ? "保存中..." : "保存记录"}
+          {submitting ? "保存中..." : isEdit ? "更新记录" : "保存记录"}
         </View>
+        {isEdit && (
+          <View className="delete-btn" onClick={handleDelete}>
+            删除记录
+          </View>
+        )}
       </View>
     </View>
   );

--- a/src/pages/medication/index/index.tsx
+++ b/src/pages/medication/index/index.tsx
@@ -31,22 +31,8 @@ export default function MedicationIndex() {
     Taro.navigateTo({ url: "/pages/medication/add/index" });
   };
 
-  const handleDelete = async (id: string) => {
-    const res = await Taro.showModal({
-      title: "确认删除",
-      content: "确定要删除这条记录吗？",
-    });
-
-    if (res.confirm) {
-      try {
-        const { medicationService: svc } = await import("../../../services/medication");
-        await svc.delete(id);
-        Taro.showToast({ title: "已删除", icon: "success" });
-        loadRecords();
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
-      }
-    }
+  const handleEdit = (id: string) => {
+    Taro.navigateTo({ url: `/pages/medication/add/index?id=${id}` });
   };
 
   return (
@@ -68,7 +54,7 @@ export default function MedicationIndex() {
       ) : (
         <View className="record-list">
           {records.map((record) => (
-            <View key={record._id} className="record-item">
+            <View key={record._id} className="record-item" onClick={() => handleEdit(record._id!)}>
               <View className="record-main">
                 <View className="record-header">
                   <Text className="record-date">
@@ -81,9 +67,6 @@ export default function MedicationIndex() {
                 {record.dosage && <Text className="medication-dosage">{record.dosage}</Text>}
 
                 {record.note && <Text className="record-note">{record.note}</Text>}
-              </View>
-              <View className="delete-btn" onClick={() => handleDelete(record._id!)}>
-                删除
               </View>
             </View>
           ))}

--- a/src/pages/records/index.tsx
+++ b/src/pages/records/index.tsx
@@ -120,7 +120,10 @@ export default function Records() {
           {/* 体感 */}
           <View className="record-card">
             <View className="card-header">
-              <View className="card-title-row">
+              <View
+                className="card-title-row"
+                onClick={() => handleNavigate("/pages/symptom/index/index")}
+              >
                 <Text className="card-icon">🌡️</Text>
                 <Text className="card-title">体感</Text>
                 <Text className="card-count">[{symptomRecords.length}条]</Text>
@@ -132,17 +135,18 @@ export default function Records() {
                 ＋
               </Text>
             </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/symptom/index/index")}
-            >
+            <View className="card-content">
               {symptomRecords.length === 0 ? (
                 <Text className="empty-hint">暂无记录</Text>
               ) : (
                 symptomRecords.slice(0, 3).map((record) => {
                   const severity = getSeverityInfo(record.severity);
                   return (
-                    <View key={record._id} className="record-item">
+                    <View
+                      key={record._id}
+                      className="record-item"
+                      onClick={() => handleNavigate(`/pages/symptom/add/index?id=${record._id}`)}
+                    >
                       <Text className="record-time">{record.time || "--:--"}</Text>
                       <Text className="record-feeling">
                         {getFeelingEmoji(record.overallFeeling)}
@@ -168,7 +172,10 @@ export default function Records() {
           {/* 用药记录 */}
           <View className="record-card">
             <View className="card-header">
-              <View className="card-title-row">
+              <View
+                className="card-title-row"
+                onClick={() => handleNavigate("/pages/medication/index/index")}
+              >
                 <Text className="card-icon">💊</Text>
                 <Text className="card-title">用药</Text>
                 <Text className="card-count">[{medicationRecords.length}条]</Text>
@@ -180,15 +187,16 @@ export default function Records() {
                 ＋
               </Text>
             </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/medication/index/index")}
-            >
+            <View className="card-content">
               {medicationRecords.length === 0 ? (
                 <Text className="empty-hint">暂无记录</Text>
               ) : (
                 medicationRecords.slice(0, 3).map((record) => (
-                  <View key={record._id} className="record-item">
+                  <View
+                    key={record._id}
+                    className="record-item"
+                    onClick={() => handleNavigate(`/pages/medication/add/index?id=${record._id}`)}
+                  >
                     <Text className="record-time">{record.time}</Text>
                     <Text className="record-desc">
                       {record.name}
@@ -203,7 +211,10 @@ export default function Records() {
           {/* 饮食记录 */}
           <View className="record-card">
             <View className="card-header">
-              <View className="card-title-row">
+              <View
+                className="card-title-row"
+                onClick={() => handleNavigate("/pages/meal/index/index")}
+              >
                 <Text className="card-icon">🍱</Text>
                 <Text className="card-title">饮食</Text>
                 <Text className="card-count">[{mealRecords.length}条]</Text>
@@ -215,15 +226,16 @@ export default function Records() {
                 ＋
               </Text>
             </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/meal/index/index")}
-            >
+            <View className="card-content">
               {mealRecords.length === 0 ? (
                 <Text className="empty-hint">暂无记录</Text>
               ) : (
                 mealRecords.slice(0, 3).map((record) => (
-                  <View key={record._id} className="record-item">
+                  <View
+                    key={record._id}
+                    className="record-item"
+                    onClick={() => handleNavigate(`/pages/meal/add/index?id=${record._id}`)}
+                  >
                     <Text className="record-time">{record.time}</Text>
                     <Text className="record-feeling">{getAmountEmoji(record.amount)}</Text>
                     <Text className="record-desc">{record.foods.join("、")}</Text>
@@ -236,7 +248,10 @@ export default function Records() {
           {/* 排便记录 */}
           <View className="record-card">
             <View className="card-header">
-              <View className="card-title-row">
+              <View
+                className="card-title-row"
+                onClick={() => handleNavigate("/pages/stool/index/index")}
+              >
                 <Text className="card-icon">💩</Text>
                 <Text className="card-title">排便</Text>
                 <Text className="card-count">[{stoolRecords.length}条]</Text>
@@ -248,15 +263,16 @@ export default function Records() {
                 ＋
               </Text>
             </View>
-            <View
-              className="card-content"
-              onClick={() => handleNavigate("/pages/stool/index/index")}
-            >
+            <View className="card-content">
               {stoolRecords.length === 0 ? (
                 <Text className="empty-hint">暂无记录</Text>
               ) : (
                 stoolRecords.slice(0, 3).map((record) => (
-                  <View key={record._id} className="record-item">
+                  <View
+                    key={record._id}
+                    className="record-item"
+                    onClick={() => handleNavigate(`/pages/stool/add/index?id=${record._id}`)}
+                  >
                     <Text className="record-time">{record.time}</Text>
                     <Text className="record-feeling">{getBristolEmoji(record.type)}</Text>
                     <Text className="record-desc">

--- a/src/pages/stool/add/index.tsx
+++ b/src/pages/stool/add/index.tsx
@@ -45,6 +45,27 @@ export default function StoolAdd() {
     }
   };
 
+  const handleDelete = async () => {
+    if (!editId) return;
+
+    const res = await Taro.showModal({
+      title: "确认删除",
+      content: "确定要删除这条记录吗？",
+    });
+
+    if (res.confirm) {
+      try {
+        await stoolService.delete(editId);
+        Taro.showToast({ title: "已删除", icon: "success" });
+        setTimeout(() => {
+          Taro.navigateBack();
+        }, 1500);
+      } catch {
+        Taro.showToast({ title: "删除失败", icon: "none" });
+      }
+    }
+  };
+
   const handleSubmit = async () => {
     if (submitting) return;
 
@@ -167,6 +188,11 @@ export default function StoolAdd() {
         <View className={`submit-btn ${submitting ? "disabled" : ""}`} onClick={handleSubmit}>
           {submitting ? "保存中..." : isEdit ? "更新记录" : "保存记录"}
         </View>
+        {isEdit && (
+          <View className="delete-btn" onClick={handleDelete}>
+            删除记录
+          </View>
+        )}
       </View>
     </View>
   );

--- a/src/pages/stool/add/index.tsx
+++ b/src/pages/stool/add/index.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Textarea, Picker } from "@tarojs/components";
-import Taro from "@tarojs/taro";
-import { useState } from "react";
+import Taro, { useRouter } from "@tarojs/taro";
+import { useState, useEffect } from "react";
 import { stoolService } from "../../../services/stool";
 import { BRISTOL_TYPES, STOOL_AMOUNTS, NOTE_SHORTCUTS } from "../../../constants/stool";
 import { formatDate, formatTime } from "../../../utils/date";
@@ -9,27 +9,63 @@ import type { StoolRecord } from "../../../types";
 import "./index.css";
 
 export default function StoolAdd() {
+  const router = useRouter();
+  const editId = router.params.id;
+  const isEdit = !!editId;
+
   const [date, setDate] = useState(formatDate());
   const [time, setTime] = useState(formatTime());
   const [bristolType, setBristolType] = useState<StoolRecord["type"]>(4);
   const [amount, setAmount] = useState<StoolRecord["amount"]>(2);
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [loading, setLoading] = useState(isEdit);
+
+  useEffect(() => {
+    if (editId) {
+      loadRecord(editId);
+    }
+  }, [editId]);
+
+  const loadRecord = async (id: string) => {
+    try {
+      const record = await stoolService.getById(id);
+      if (record) {
+        setDate(record.date);
+        setTime(record.time || formatTime());
+        setBristolType(record.type);
+        setAmount(record.amount);
+        setNote(record.note || "");
+      }
+    } catch (error) {
+      console.error("加载记录失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleSubmit = async () => {
     if (submitting) return;
 
     setSubmitting(true);
     try {
-      await stoolService.add({
+      const data = {
         date,
         time,
         type: bristolType,
         amount,
         note: note.trim() || undefined,
-      });
+      };
 
-      Taro.showToast({ title: "记录成功", icon: "success" });
+      if (isEdit && editId) {
+        await stoolService.update(editId, data);
+        Taro.showToast({ title: "更新成功", icon: "success" });
+      } else {
+        await stoolService.add(data);
+        Taro.showToast({ title: "记录成功", icon: "success" });
+      }
+
       setTimeout(() => {
         Taro.navigateBack();
       }, 1500);
@@ -40,6 +76,14 @@ export default function StoolAdd() {
       setSubmitting(false);
     }
   };
+
+  if (loading) {
+    return (
+      <View className="add-page">
+        <View className="loading">加载中...</View>
+      </View>
+    );
+  }
 
   return (
     <View className="add-page">
@@ -121,7 +165,7 @@ export default function StoolAdd() {
       {/* 提交按钮 */}
       <View className="submit-section">
         <View className={`submit-btn ${submitting ? "disabled" : ""}`} onClick={handleSubmit}>
-          {submitting ? "保存中..." : "保存记录"}
+          {submitting ? "保存中..." : isEdit ? "更新记录" : "保存记录"}
         </View>
       </View>
     </View>

--- a/src/pages/stool/index/index.tsx
+++ b/src/pages/stool/index/index.tsx
@@ -33,22 +33,8 @@ export default function StoolIndex() {
     Taro.navigateTo({ url: "/pages/stool/add/index" });
   };
 
-  const handleDelete = async (id: string) => {
-    const res = await Taro.showModal({
-      title: "确认删除",
-      content: "确定要删除这条记录吗？",
-    });
-
-    if (res.confirm) {
-      try {
-        const { stoolService: svc } = await import("../../../services/stool");
-        await svc.delete(id);
-        Taro.showToast({ title: "已删除", icon: "success" });
-        loadRecords();
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
-      }
-    }
+  const handleEdit = (id: string) => {
+    Taro.navigateTo({ url: `/pages/stool/add/index?id=${id}` });
   };
 
   const getBristolInfo = (type: number) => {
@@ -80,7 +66,11 @@ export default function StoolIndex() {
           {records.map((record) => {
             const bristol = getBristolInfo(record.type);
             return (
-              <View key={record._id} className="record-item">
+              <View
+                key={record._id}
+                className="record-item"
+                onClick={() => handleEdit(record._id!)}
+              >
                 <View className="record-main">
                   <View className="record-header">
                     <Text className="record-date">
@@ -104,9 +94,6 @@ export default function StoolIndex() {
                   </View>
 
                   {record.note && <Text className="record-note">{record.note}</Text>}
-                </View>
-                <View className="delete-btn" onClick={() => handleDelete(record._id!)}>
-                  删除
                 </View>
               </View>
             );

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -110,6 +110,27 @@ export default function SymptomAdd() {
     }
   };
 
+  const handleDelete = async () => {
+    if (!editId) return;
+
+    const res = await Taro.showModal({
+      title: "确认删除",
+      content: "确定要删除这条记录吗？",
+    });
+
+    if (res.confirm) {
+      try {
+        await symptomService.delete(editId);
+        Taro.showToast({ title: "已删除", icon: "success" });
+        setTimeout(() => {
+          Taro.navigateBack();
+        }, 1500);
+      } catch {
+        Taro.showToast({ title: "删除失败", icon: "none" });
+      }
+    }
+  };
+
   const handleSubmit = async () => {
     if (submitting) return;
 
@@ -261,6 +282,11 @@ export default function SymptomAdd() {
         <View className={`submit-btn ${submitting ? "disabled" : ""}`} onClick={handleSubmit}>
           {submitting ? "保存中..." : isEdit ? "更新记录" : "保存记录"}
         </View>
+        {isEdit && (
+          <View className="delete-btn" onClick={handleDelete}>
+            删除记录
+          </View>
+        )}
       </View>
     </View>
   );

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Textarea, Picker, Input } from "@tarojs/components";
-import Taro, { useDidShow } from "@tarojs/taro";
-import { useState } from "react";
+import Taro, { useDidShow, useRouter } from "@tarojs/taro";
+import { useState, useEffect } from "react";
 import { symptomService } from "../../../services/symptom";
 import { SYMPTOM_SHORTCUTS, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../../constants/symptom";
 import { formatDate, formatTime } from "../../../utils/date";
@@ -30,6 +30,10 @@ function removeCustomSymptom(symptom: string) {
 }
 
 export default function SymptomAdd() {
+  const router = useRouter();
+  const editId = router.params.id;
+  const isEdit = !!editId;
+
   const [date, setDate] = useState(formatDate());
   const [time, setTime] = useState(formatTime());
   const [symptoms, setSymptoms] = useState<string[]>([]);
@@ -39,6 +43,32 @@ export default function SymptomAdd() {
   const [overallFeeling, setOverallFeeling] = useState<1 | 2 | 3 | 4 | 5>(3);
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [loading, setLoading] = useState(isEdit);
+
+  useEffect(() => {
+    if (editId) {
+      loadRecord(editId);
+    }
+  }, [editId]);
+
+  const loadRecord = async (id: string) => {
+    try {
+      const record = await symptomService.getById(id);
+      if (record) {
+        setDate(record.date);
+        setTime(record.time || formatTime());
+        setSymptoms(record.symptoms);
+        setSeverity(record.severity);
+        setOverallFeeling(record.overallFeeling);
+        setNote(record.note || "");
+      }
+    } catch (error) {
+      console.error("加载记录失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useDidShow(() => {
     setSavedCustomSymptoms(getStoredCustomSymptoms());
@@ -85,16 +115,23 @@ export default function SymptomAdd() {
 
     setSubmitting(true);
     try {
-      await symptomService.add({
+      const data = {
         date,
         time,
         symptoms,
         severity: symptoms.length > 0 ? severity : undefined,
         overallFeeling,
         note: note.trim() || undefined,
-      });
+      };
 
-      Taro.showToast({ title: "记录成功", icon: "success" });
+      if (isEdit && editId) {
+        await symptomService.update(editId, data);
+        Taro.showToast({ title: "更新成功", icon: "success" });
+      } else {
+        await symptomService.add(data);
+        Taro.showToast({ title: "记录成功", icon: "success" });
+      }
+
       setTimeout(() => {
         Taro.navigateBack();
       }, 1500);
@@ -105,6 +142,14 @@ export default function SymptomAdd() {
       setSubmitting(false);
     }
   };
+
+  if (loading) {
+    return (
+      <View className="add-page">
+        <View className="loading">加载中...</View>
+      </View>
+    );
+  }
 
   return (
     <View className="add-page">
@@ -214,7 +259,7 @@ export default function SymptomAdd() {
       {/* 提交按钮 */}
       <View className="submit-section">
         <View className={`submit-btn ${submitting ? "disabled" : ""}`} onClick={handleSubmit}>
-          {submitting ? "保存中..." : "保存记录"}
+          {submitting ? "保存中..." : isEdit ? "更新记录" : "保存记录"}
         </View>
       </View>
     </View>

--- a/src/pages/symptom/index/index.tsx
+++ b/src/pages/symptom/index/index.tsx
@@ -32,22 +32,8 @@ export default function SymptomIndex() {
     Taro.navigateTo({ url: "/pages/symptom/add/index" });
   };
 
-  const handleDelete = async (id: string) => {
-    const res = await Taro.showModal({
-      title: "确认删除",
-      content: "确定要删除这条记录吗？",
-    });
-
-    if (res.confirm) {
-      try {
-        const { symptomService: svc } = await import("../../../services/symptom");
-        await svc.delete(id);
-        Taro.showToast({ title: "已删除", icon: "success" });
-        loadRecords();
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
-      }
-    }
+  const handleEdit = (id: string) => {
+    Taro.navigateTo({ url: `/pages/symptom/add/index?id=${id}` });
   };
 
   const getSeverityInfo = (severity?: 1 | 2 | 3) => {
@@ -80,7 +66,11 @@ export default function SymptomIndex() {
           {records.map((record) => {
             const feeling = getFeelingInfo(record.overallFeeling);
             return (
-              <View key={record._id} className="record-item">
+              <View
+                key={record._id}
+                className="record-item"
+                onClick={() => handleEdit(record._id!)}
+              >
                 <View className="record-main">
                   <View className="record-header">
                     <Text className="record-date">
@@ -112,9 +102,6 @@ export default function SymptomIndex() {
                   )}
 
                   {record.note && <Text className="record-note">{record.note}</Text>}
-                </View>
-                <View className="delete-btn" onClick={() => handleDelete(record._id!)}>
-                  删除
                 </View>
               </View>
             );

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -60,5 +60,19 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
         .get();
       return res.data as T[];
     },
+
+    async getById(id: string): Promise<T | null> {
+      const db = getDatabase();
+      const res = await db.collection(collection).doc(id).get();
+      return (res.data as T) || null;
+    },
+
+    async update(
+      id: string,
+      data: Partial<Omit<T, "_id" | "userId" | "createdAt">>,
+    ): Promise<void> {
+      const db = getDatabase();
+      await db.collection(collection).doc(id).update({ data });
+    },
   };
 }

--- a/src/services/symptom.test.ts
+++ b/src/services/symptom.test.ts
@@ -118,4 +118,52 @@ describe("symptom service", () => {
       await expect(symptomService.delete("non_existent_id")).resolves.not.toThrow();
     });
   });
+
+  describe("getById", () => {
+    it("should return a record by id", async () => {
+      const id = await symptomService.add({
+        date: "2026-04-12",
+        time: "14:00",
+        symptoms: ["腹痛"],
+        severity: 2,
+        overallFeeling: 2,
+        note: "Test record",
+      });
+
+      const record = await symptomService.getById(id);
+
+      expect(record).toBeDefined();
+      expect(record?.date).toBe("2026-04-12");
+      expect(record?.time).toBe("14:00");
+      expect(record?.symptoms).toEqual(["腹痛"]);
+      expect(record?.overallFeeling).toBe(2);
+    });
+
+    it("should return null for non-existent id", async () => {
+      const record = await symptomService.getById("non_existent_id");
+      expect(record).toBeNull();
+    });
+  });
+
+  describe("update", () => {
+    it("should update a record", async () => {
+      const id = await symptomService.add({
+        date: "2026-04-12",
+        time: "10:00",
+        symptoms: [],
+        overallFeeling: 3,
+      });
+
+      await symptomService.update(id, {
+        time: "11:00",
+        symptoms: ["腹胀"],
+        overallFeeling: 4,
+      });
+
+      const updated = await symptomService.getById(id);
+      expect(updated?.time).toBe("11:00");
+      expect(updated?.symptoms).toEqual(["腹胀"]);
+      expect(updated?.overallFeeling).toBe(4);
+    });
+  });
 });

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -70,3 +70,15 @@
 .submit-btn.disabled {
   background-color: #ccc;
 }
+
+.submit-section .delete-btn {
+  width: 100%;
+  padding: 28px;
+  margin-top: 16px;
+  background-color: #fff;
+  color: #f5222d;
+  font-size: 32px;
+  text-align: center;
+  border-radius: 12px;
+  border: 1px solid #f5222d;
+}


### PR DESCRIPTION
## Summary

- 添加 getById 和 update 方法到基础服务层
- 四个添加页面（体感、饮食、排便、用药）支持编辑模式
- 二级列表页去掉删除按钮，点击记录进入编辑页
- 记录页区分点击目标：
  - 点击卡片标题 → 进入历史列表页
  - 点击单条记录 → 进入编辑页

交互优化：
```
┌─────────────────────────────┐
│ 🌡️ 体感 [2条]    → 历史列表  │  ← 点击标题
├─────────────────────────────┤
│ 10:30 😐 腹胀    → 编辑页    │  ← 点击记录
│ 14:00 😟 腹痛    → 编辑页    │
└─────────────────────────────┘
```

Closes #51

## Test plan

- [ ] 记录页点击卡片标题进入历史列表
- [ ] 记录页点击单条记录进入编辑页
- [ ] 二级列表页点击记录进入编辑页
- [ ] 编辑页正确加载数据并可更新
- [ ] 集成测试通过

🤖 Generated with [Claude Code](https://claude.ai/claude-code)