### PR TITLE
refactor(types): extract BaseRecord interface

### DIFF
--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -1,12 +1,7 @@
 import { getDatabase, getOpenId } from "../utils/cloud";
+import type { BaseRecord } from "../types";
 
-interface BaseRecord {
-  _id?: string;
-  userId: string;
-  date: string;
-  createdAt: Date;
-  deletedAt?: Date;
-}
+export type { BaseRecord };
 
 export function createRecordService<T extends BaseRecord>(collection: string) {
   return {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,55 +6,38 @@ export interface User {
   createdAt: Date;
 }
 
-// 症状记录
-export interface SymptomRecord {
+// 基础记录 - 所有记录共有的属性
+export interface BaseRecord {
   _id?: string;
   userId: string;
   date: string; // 2026-04-10
   time: string; // 08:30
+  note?: string;
+  createdAt: Date;
+  deletedAt?: Date;
+}
+
+// 症状记录
+export interface SymptomRecord extends BaseRecord {
   symptoms: string[]; // 症状列表
   severity?: 1 | 2 | 3; // 整体严重程度：轻度、中度、重度
   overallFeeling: 1 | 2 | 3 | 4 | 5; // 整体感受 1很差 - 5很好
-  note?: string;
-  createdAt: Date;
-  deletedAt?: Date;
 }
 
 // 饮食记录
-export interface MealRecord {
-  _id?: string;
-  userId: string;
-  date: string;
-  time: string;
+export interface MealRecord extends BaseRecord {
   foods: string[];
   amount: 1 | 2 | 3; // 1-少量 2-适中 3-大量
-  note?: string;
-  createdAt: Date;
-  deletedAt?: Date;
 }
 
 // 排便记录
-export interface StoolRecord {
-  _id?: string;
-  userId: string;
-  date: string;
-  time: string;
+export interface StoolRecord extends BaseRecord {
   type: 1 | 2 | 3 | 4 | 5 | 6 | 7; // Bristol 分类
   amount: 1 | 2 | 3; // 1-少量 2-适中 3-大量
-  note?: string;
-  createdAt: Date;
-  deletedAt?: Date;
 }
 
 // 用药记录
-export interface MedicationRecord {
-  _id?: string;
-  userId: string;
-  date: string;
-  time: string;
+export interface MedicationRecord extends BaseRecord {
   name: string;
   dosage: string;
-  note?: string;
-  createdAt: Date;
-  deletedAt?: Date;
 }


### PR DESCRIPTION
## Summary
- Extract common fields (`userId`, `date`, `time`, `note`, `createdAt`, `deletedAt`) into shared `BaseRecord` interface
- All record types (`SymptomRecord`, `MealRecord`, `StoolRecord`, `MedicationRecord`) now extend `BaseRecord`
- Remove duplicate `BaseRecord` definition from `services/base.ts`, import from `types` instead

## Test plan
- [x] All integration tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)