### PR TITLE
feat(settings): add privacy policy page

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -11,6 +11,7 @@ export default defineAppConfig({
     "pages/stool/add/index",
     "pages/medication/index/index",
     "pages/medication/add/index",
+    "pages/privacy/index",
   ],
   window: {
     backgroundTextStyle: "light",

--- a/src/pages/privacy/index.config.ts
+++ b/src/pages/privacy/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: "隐私政策",
+});

--- a/src/pages/privacy/index.css
+++ b/src/pages/privacy/index.css
@@ -1,0 +1,26 @@
+.privacy-page {
+  min-height: 100vh;
+  padding: 32px;
+  background-color: #f5f5f5;
+}
+
+.section {
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 28px;
+  margin-bottom: 24px;
+}
+
+.section-title {
+  font-size: 30px;
+  font-weight: 600;
+  color: #333;
+  display: block;
+  margin-bottom: 16px;
+}
+
+.section-content {
+  font-size: 28px;
+  color: #666;
+  line-height: 1.6;
+}

--- a/src/pages/privacy/index.tsx
+++ b/src/pages/privacy/index.tsx
@@ -1,0 +1,57 @@
+import { View, Text } from "@tarojs/components";
+import "./index.css";
+
+export default function Privacy() {
+  return (
+    <View className="privacy-page">
+      <View className="section">
+        <Text className="section-title">数据收集</Text>
+        <Text className="section-content">
+          本应用收集您主动填写的健康记录数据，包括排便记录、症状记录、饮食记录和用药记录。这些数据仅用于您个人的健康管理。
+        </Text>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">数据存储</Text>
+        <Text className="section-content">
+          您的数据存储在微信云开发平台，与您的微信账号关联。数据采用加密传输，仅您本人可以访问。
+        </Text>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">数据使用</Text>
+        <Text className="section-content">
+          您的数据仅用于在本应用内展示，帮助您记录和回顾个人健康状况。我们不会将您的数据用于任何其他目的。
+        </Text>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">数据共享</Text>
+        <Text className="section-content">
+          我们不会与任何第三方共享您的健康数据。您的数据完全属于您个人。
+        </Text>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">数据导出</Text>
+        <Text className="section-content">
+          您可以在设置页面导出您的全部数据，获取 JSON 格式的数据副本。
+        </Text>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">数据删除</Text>
+        <Text className="section-content">
+          您可以在设置页面一键删除全部数据。一旦执行删除操作，我们将从服务器彻底清除您的所有健康记录和个人资料，包括排便、症状、饮食、用药记录及头像等。此操作不可撤销，程序后台也无法恢复，请务必谨慎操作。
+        </Text>
+      </View>
+
+      <View className="section">
+        <Text className="section-title">联系我们</Text>
+        <Text className="section-content">
+          如有任何隐私相关问题，请通过设置页面的"联系开发者"功能与我们联系。
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/src/pages/settings/index.css
+++ b/src/pages/settings/index.css
@@ -88,6 +88,11 @@
   color: #999;
 }
 
+.about-arrow {
+  font-size: 36px;
+  color: #ccc;
+}
+
 /* 数据管理 */
 .data-section {
   background-color: #fff;
@@ -122,6 +127,7 @@
 .data-label-danger {
   color: #ff4d4f;
 }
+
 
 /* 联系客服 */
 .contact-section {

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Image, Button } from "@tarojs/components";
-import { useDidShow } from "@tarojs/taro";
+import Taro, { useDidShow } from "@tarojs/taro";
 import { useState, useCallback } from "react";
 import { getUserSettings, getDefaultNickname } from "../../services/user";
 import { saveExportToFile } from "../../services/export";
@@ -82,6 +82,13 @@ export default function Settings() {
         <View className="about-item">
           <Text className="about-label">名称</Text>
           <Text className="about-value">{APP_NAME}</Text>
+        </View>
+        <View
+          className="about-item"
+          onClick={() => Taro.navigateTo({ url: "/pages/privacy/index" })}
+        >
+          <Text className="about-label">隐私政策</Text>
+          <Text className="about-arrow">›</Text>
         </View>
       </View>
 


### PR DESCRIPTION
## Summary
- Add privacy policy page explaining:
  - Data collection (health records user fills in)
  - Data storage (WeChat CloudBase, encrypted)
  - Data usage (personal viewing only)
  - No third-party sharing
  - Data deletion options
- Add link to privacy policy in settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)