### PR TITLE
fix(services): add userId validation in getById, update, delete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,18 @@ Test files: `src/services/**/*.test.ts`
 
 Integration tests use the in-memory fake database (`TARO_APP_ENV=test`). The fake database supports: `add`, `where`, `orderBy`, `limit`, `get`, `doc`, `remove`, `update`.
 
+## Cloud Database (tcb CLI)
+
+Use `tcb` CLI to manage cloud resources. Environment ID: `cloud1-8gzx205084c1da0f`
+
+```bash
+# Check collection permissions
+tcb permission get collection -e cloud1-8gzx205084c1da0f
+
+# List environments
+tcb env list
+```
+
 ## Build-time Constants
 
 Use `defineConstants` in `config/index.ts` for environment-specific values. Do not use `process.env` directly in source code — it doesn't exist at runtime in mini programs.

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -32,9 +32,10 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
 
     async delete(id: string): Promise<void> {
       const db = getDatabase();
+      const userId = await getOpenId();
       await db
         .collection(collection)
-        .doc(id)
+        .where({ _id: id, userId })
         .update({
           data: { deletedAt: new Date() },
         });
@@ -58,8 +59,9 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
 
     async getById(id: string): Promise<T | null> {
       const db = getDatabase();
-      const res = await db.collection(collection).doc(id).get();
-      return (res.data as T) || null;
+      const userId = await getOpenId();
+      const res = await db.collection(collection).where({ _id: id, userId }).get();
+      return (res.data[0] as T) || null;
     },
 
     async update(
@@ -67,7 +69,8 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
       data: Partial<Omit<T, "_id" | "userId" | "createdAt">>,
     ): Promise<void> {
       const db = getDatabase();
-      await db.collection(collection).doc(id).update({ data });
+      const userId = await getOpenId();
+      await db.collection(collection).where({ _id: id, userId }).update({ data });
     },
   };
 }

--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -87,6 +87,18 @@ function createMemoryCollection(data: Record<string, unknown>[]) {
       data.push({ _id, ...doc });
       return { _id };
     },
+    async update({ data: updates }: { data: Record<string, unknown> }) {
+      const items = data.filter((item) => {
+        return Object.entries(filters).every(([key, value]) => {
+          if (value === EXISTS_FALSE) {
+            return !(key in item) || item[key] === undefined || item[key] === null;
+          }
+          return item[key] === value;
+        });
+      });
+      items.forEach((item) => Object.assign(item, updates));
+      return { stats: { updated: items.length } };
+    },
     doc(id: string) {
       return {
         async get() {


### PR DESCRIPTION
## Summary
- Add userId validation to `getById`, `update`, `delete` methods in base service
- Defense-in-depth security measure complementing cloud database's private permission rules
- Add `where().update()` support to fake database for integration tests

## Test plan
- [x] Integration tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)

Closes #58

🤖 Generated with [Claude Code](https://claude.ai/claude-code)