### PR TITLE
feat(labtest): add dedicated list page for lab test records

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -11,6 +11,7 @@ export default defineAppConfig({
     "pages/stool/add/index",
     "pages/medication/index/index",
     "pages/medication/add/index",
+    "pages/labtest/index/index",
     "pages/labtest/add/index",
     "pages/labtest/mosaic/index",
     "pages/privacy/index",

--- a/src/pages/labtest/index/index.css
+++ b/src/pages/labtest/index/index.css
@@ -1,0 +1,108 @@
+.health-page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+  padding-bottom: 40px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 32px;
+  background-color: #fff;
+}
+
+.title {
+  font-size: 36px;
+  font-weight: 600;
+  color: #333;
+}
+
+.add-btn {
+  padding: 12px 24px;
+  background-color: #07c160;
+  color: #fff;
+  font-size: 28px;
+  border-radius: 8px;
+}
+
+.loading,
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 120px 32px;
+}
+
+.empty-text {
+  font-size: 32px;
+  color: #999;
+  margin-bottom: 16px;
+}
+
+.empty-hint {
+  font-size: 26px;
+  color: #ccc;
+}
+
+.record-list {
+  padding: 24px;
+}
+
+.record-item {
+  display: flex;
+  align-items: stretch;
+  background-color: #fff;
+  border-radius: 16px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.record-main {
+  flex: 1;
+  padding: 28px;
+}
+
+.record-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.record-date {
+  font-size: 28px;
+  color: #666;
+}
+
+.record-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.stat-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background-color: #f0f0f0;
+  border-radius: 8px;
+}
+
+.stat-icon {
+  font-size: 24px;
+}
+
+.stat-text {
+  font-size: 24px;
+  color: #666;
+}
+
+.record-note {
+  font-size: 26px;
+  color: #999;
+  line-height: 1.5;
+}

--- a/src/pages/labtest/index/index.tsx
+++ b/src/pages/labtest/index/index.tsx
@@ -1,0 +1,91 @@
+import { View, Text } from "@tarojs/components";
+import Taro, { useDidShow } from "@tarojs/taro";
+import { useState } from "react";
+import { labTestService } from "../../../services/labtest";
+import { formatDisplayDate } from "../../../utils/date";
+import type { LabTestRecord } from "../../../types";
+import "./index.css";
+
+export default function LabTestIndex() {
+  const [records, setRecords] = useState<LabTestRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useDidShow(() => {
+    loadRecords();
+  });
+
+  const loadRecords = async () => {
+    setLoading(true);
+    try {
+      const data = await labTestService.getRecent(50);
+      setRecords(data);
+    } catch (error) {
+      console.error("加载记录失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAdd = () => {
+    Taro.navigateTo({ url: "/pages/labtest/add/index" });
+  };
+
+  const handleEdit = (id: string) => {
+    Taro.navigateTo({ url: `/pages/labtest/add/index?id=${id}` });
+  };
+
+  return (
+    <View className="health-page">
+      <View className="header">
+        <Text className="title">化验记录</Text>
+        <View className="add-btn" onClick={handleAdd}>
+          + 添加
+        </View>
+      </View>
+
+      {loading ? (
+        <View className="loading">加载中...</View>
+      ) : records.length === 0 ? (
+        <View className="empty">
+          <Text className="empty-text">暂无记录</Text>
+          <Text className="empty-hint">点击右上角添加记录</Text>
+        </View>
+      ) : (
+        <View className="record-list">
+          {records.map((record) => (
+            <View
+              key={record._id}
+              className="record-item"
+              onClick={() => handleEdit(record._id!)}
+            >
+              <View className="record-main">
+                <View className="record-header">
+                  <Text className="record-date">
+                    {formatDisplayDate(record.date)}
+                    {record.time && ` ${record.time}`}
+                  </Text>
+                </View>
+
+                <View className="record-stats">
+                  <View className="stat-badge">
+                    <Text className="stat-icon">🖼️</Text>
+                    <Text className="stat-text">{record.imageFileIds.length}张图片</Text>
+                  </View>
+                  {record.indicators.length > 0 && (
+                    <View className="stat-badge">
+                      <Text className="stat-icon">📊</Text>
+                      <Text className="stat-text">{record.indicators.length}项指标</Text>
+                    </View>
+                  )}
+                </View>
+
+                {record.note && <Text className="record-note">{record.note}</Text>}
+              </View>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/pages/records/index.tsx
+++ b/src/pages/records/index.tsx
@@ -298,7 +298,10 @@ export default function Records() {
           {/* 化验记录 */}
           <View className="record-card">
             <View className="card-header">
-              <View className="card-title-row">
+              <View
+                className="card-title-row"
+                onClick={() => handleNavigate("/pages/labtest/index/index")}
+              >
                 <Text className="card-icon">🧪</Text>
                 <Text className="card-title">化验</Text>
                 <Text className="card-count">[{labTestRecords.length}条]</Text>


### PR DESCRIPTION
## Summary
- Add `/pages/labtest/index/index.tsx` list page showing all lab test records sorted by date
- Each item displays: date, time, number of images, number of indicators
- Click to edit the record
- Add navigation from records page title row

Closes #82

## Test plan
- [ ] Navigate to labtest list from records page by clicking "化验" title
- [ ] Verify records are displayed with correct info (date, time, images count, indicators count)
- [ ] Click a record to edit it
- [ ] Add new record from list page

🤖 Generated with [Claude Code](https://claude.com/claude-code)