### PR TITLE
fix(settings): convert cloud fileID to temp URL for avatar display

### DIFF
--- a/src/components/ProfilePopup/index.tsx
+++ b/src/components/ProfilePopup/index.tsx
@@ -62,22 +62,25 @@ export default function ProfilePopup({
     setSaving(true);
 
     try {
-      let avatarFileId = currentAvatar;
+      let avatarToSave: string | undefined;
+      let avatarToDisplay: string | undefined = currentAvatar;
 
       // 如果有新选择的头像，先上传
       if (tempAvatarPath) {
-        avatarFileId = await uploadAvatar(tempAvatarPath);
+        const { fileID, tempURL } = await uploadAvatar(tempAvatarPath);
+        avatarToSave = fileID; // 保存 fileID 到数据库
+        avatarToDisplay = tempURL; // 用临时 URL 显示
       }
 
-      // 更新用户设置
+      // 更新用户设置（只有新上传的头像才需要更新）
       await updateUserSettings({
         nickname: currentNickname.trim(),
-        avatar: avatarFileId,
+        ...(avatarToSave && { avatar: avatarToSave }),
       });
 
       onSave({
         nickname: currentNickname.trim(),
-        avatar: avatarFileId,
+        avatar: avatarToDisplay,
       });
 
       Taro.showToast({ title: "保存成功", icon: "success" });

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -11,6 +11,15 @@ interface UserSettings {
   updatedAt?: Date;
 }
 
+// 将云存储 fileID 转换为临时访问 URL
+async function getAvatarUrl(fileID: string): Promise<string> {
+  const res = await Taro.cloud.getTempFileURL({ fileList: [fileID] });
+  if (res.fileList[0]?.status === 0) {
+    return res.fileList[0].tempFileURL;
+  }
+  return fileID; // 转换失败时返回原值
+}
+
 // 获取当前用户设置（不存在则自动创建）
 export async function getUserSettings(): Promise<UserSettings> {
   const db = getDatabase();
@@ -20,7 +29,12 @@ export async function getUserSettings(): Promise<UserSettings> {
   const res = await db.collection(COLLECTION).where({ _id: userId }).limit(1).get();
 
   if (res.data && res.data.length > 0) {
-    return res.data[0] as UserSettings;
+    const settings = res.data[0] as UserSettings;
+    // 如果有头像 fileID，转换为临时 URL
+    if (settings.avatar && settings.avatar.startsWith("cloud://")) {
+      settings.avatar = await getAvatarUrl(settings.avatar);
+    }
+    return settings;
   }
 
   // 不存在，创建新记录
@@ -60,8 +74,10 @@ export async function updateUserSettings(data: {
     });
 }
 
-// 上传头像到云存储
-export async function uploadAvatar(tempFilePath: string): Promise<string> {
+// 上传头像到云存储，返回 fileID 和临时访问 URL
+export async function uploadAvatar(
+  tempFilePath: string
+): Promise<{ fileID: string; tempURL: string }> {
   const openId = await getOpenId();
   const cloudPath = `${openId}/avatar.jpg`;
 
@@ -70,5 +86,6 @@ export async function uploadAvatar(tempFilePath: string): Promise<string> {
     filePath: tempFilePath,
   });
 
-  return res.fileID;
+  const tempURL = await getAvatarUrl(res.fileID);
+  return { fileID: res.fileID, tempURL };
 }


### PR DESCRIPTION
## Summary
- Cloud storage fileIDs (e.g., `cloud://xxx/avatar.jpg`) cannot be used directly as `<Image>` src
- Add `getAvatarUrl()` to convert fileID to temporary URL via `getTempFileURL`
- `getUserSettings()` now converts avatar fileID to temp URL before returning
- `uploadAvatar()` returns both fileID (for DB storage) and tempURL (for display)

## Test plan
- [ ] Upload new avatar in settings page
- [ ] Verify avatar displays correctly after save
- [ ] Reload settings page and verify avatar still displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)