### PR TITLE
refactor(mosaic): change from box selection to brush mode

### DIFF
--- a/scripts/test-ai-models.ts
+++ b/scripts/test-ai-models.ts
@@ -1,7 +1,24 @@
 import * as fs from "fs";
 import * as path from "path";
 
-const MODELS = ["Qwen/Qwen3.5-35B-A3B", "zai-org/GLM-4.6V", "PaddlePaddle/PaddleOCR-VL-1.5"];
+interface ModelConfig {
+  model: string;
+  apiUrl: string;
+  apiKeyEnv: string;
+}
+
+const MODELS: ModelConfig[] = [
+  {
+    model: "doubao-seed-2-0-lite-260215",
+    apiUrl: "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
+    apiKeyEnv: "ARK_API_KEY",
+  },
+  {
+    model: "Qwen/Qwen3-VL-32B-Instruct",
+    apiUrl: "https://api.siliconflow.cn/v1/chat/completions",
+    apiKeyEnv: "SILICONFLOW_API_KEY",
+  },
+];
 
 const SYSTEM_PROMPT = `请识别图片中的所有文字，按原始布局输出。`;
 
@@ -13,28 +30,28 @@ async function imageToBase64(filePath: string): Promise<string> {
   return buffer.toString("base64");
 }
 
-async function testModel(model: string, imageBase64: string): Promise<void> {
+async function testModel(config: ModelConfig, imageBase64: string): Promise<void> {
   console.log(`\n${"=".repeat(60)}`);
-  console.log(`Testing model: ${model}`);
+  console.log(`Testing model: ${config.model}`);
   console.log("=".repeat(60));
 
-  const apiKey = process.env.SILICONFLOW_API_KEY;
+  const apiKey = process.env[config.apiKeyEnv];
   if (!apiKey) {
-    console.error("Error: SILICONFLOW_API_KEY environment variable is not set");
-    process.exit(1);
+    console.error(`Error: ${config.apiKeyEnv} environment variable is not set`);
+    return;
   }
 
   const startTime = Date.now();
 
   try {
-    const response = await fetch("https://api.siliconflow.cn/v1/chat/completions", {
+    const response = await fetch(config.apiUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model,
+        model: config.model,
         messages: [
           {
             role: "system",
@@ -90,7 +107,7 @@ async function testModel(model: string, imageBase64: string): Promise<void> {
       );
     }
   } catch (error) {
-    console.error(`Error testing ${model}:`, error);
+    console.error(`Error testing ${config.model}:`, error);
   }
 }
 
@@ -101,8 +118,8 @@ async function main() {
   const imageBase64 = await imageToBase64(imagePath);
   console.log(`Image size: ${(imageBase64.length / 1024).toFixed(2)} KB (base64)`);
 
-  for (const model of MODELS) {
-    await testModel(model, imageBase64);
+  for (const config of MODELS) {
+    await testModel(config, imageBase64);
   }
 
   console.log("\n" + "=".repeat(60));

--- a/src/pages/labtest/mosaic/index.css
+++ b/src/pages/labtest/mosaic/index.css
@@ -35,11 +35,20 @@
   position: relative;
 }
 
-.selection-rect {
+.select-hint {
   position: absolute;
-  border: 4px dashed #07c160;
-  background-color: rgb(7 193 96 / 20%);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgb(0 0 0 / 60%);
+  padding: 16px 24px;
+  border-radius: 8px;
   pointer-events: none;
+}
+
+.select-hint-text {
+  font-size: 28px;
+  color: #fff;
 }
 
 .action-bar {
@@ -58,14 +67,16 @@
   text-align: center;
 }
 
-.undo-btn {
+.secondary-btn {
   background-color: #555;
   color: #fff;
+  flex: 0.6;
 }
 
 .save-btn {
   background-color: #07c160;
   color: #fff;
+  flex: 1;
 }
 
 .action-btn.disabled {

--- a/src/pages/labtest/mosaic/index.tsx
+++ b/src/pages/labtest/mosaic/index.tsx
@@ -3,19 +3,21 @@ import Taro, { useRouter } from "@tarojs/taro";
 import { useState, useRef, useEffect } from "react";
 import "./index.css";
 
-interface Rect {
+interface Point {
   x: number;
   y: number;
-  width: number;
-  height: number;
 }
 
 const TIPS: Record<string, string> = {
   labtest:
-    '您上传的图片将用于 AI 自动识别化验指标。请用手指框选并遮盖姓名、身份证号、住址、电话等敏感信息，确认图片中不含敏感个人信息后再点击"确认"。',
-  exam:
-    '您上传的图片将用于 AI 自动识别检查结论。请用手指框选并遮盖姓名、身份证号、住址、电话等敏感信息，确认图片中不含敏感个人信息后再点击"确认"。',
+    '您上传的图片将用于 AI 自动识别化验指标。请用手指涂抹遮盖姓名、身份证号、住址、电话等敏感信息，确认图片中不含敏感个人信息后再点击"确认"。',
+  exam: '您上传的图片将用于 AI 自动识别检查结论。请用手指涂抹遮盖姓名、身份证号、住址、电话等敏感信息，确认图片中不含敏感个人信息后再点击"确认"。',
 };
+
+// 马赛克笔刷大小
+const BRUSH_SIZE = 30;
+// 马赛克块大小
+const BLOCK_SIZE = 10;
 
 export default function MosaicEditor() {
   const router = useRouter();
@@ -25,11 +27,12 @@ export default function MosaicEditor() {
 
   const [imageInfo, setImageInfo] = useState<{ width: number; height: number } | null>(null);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
-  const [selecting, setSelecting] = useState(false);
-  const [startPoint, setStartPoint] = useState({ x: 0, y: 0 });
-  const [currentRect, setCurrentRect] = useState<Rect | null>(null);
-  const [mosaicRects, setMosaicRects] = useState<Rect[]>([]);
+  const [drawing, setDrawing] = useState(false);
   const [processing, setProcessing] = useState(false);
+  // 记录所有涂抹过的点，用于撤销
+  const [strokeHistory, setStrokeHistory] = useState<Point[][]>([]);
+  const currentStrokeRef = useRef<Point[]>([]);
+  const lastPointRef = useRef<Point | null>(null);
 
   const canvasRef = useRef<string>("mosaicCanvas");
 
@@ -81,52 +84,136 @@ export default function MosaicEditor() {
     ctx.draw();
   };
 
+  const vibrateLight = () => {
+    try {
+      Taro.vibrateShort({ type: "light" });
+    } catch {
+      // 忽略振动失败
+    }
+  };
+
+  // 在某个点绘制马赛克
+  const drawMosaicAt = (ctx: Taro.CanvasContext, point: Point) => {
+    const halfBrush = BRUSH_SIZE / 2;
+    const startX = Math.floor((point.x - halfBrush) / BLOCK_SIZE) * BLOCK_SIZE;
+    const startY = Math.floor((point.y - halfBrush) / BLOCK_SIZE) * BLOCK_SIZE;
+    const endX = point.x + halfBrush;
+    const endY = point.y + halfBrush;
+
+    for (let x = startX; x < endX; x += BLOCK_SIZE) {
+      for (let y = startY; y < endY; y += BLOCK_SIZE) {
+        const gray = Math.floor(Math.random() * 100) + 100;
+        ctx.setFillStyle(`rgb(${gray}, ${gray}, ${gray})`);
+        ctx.fillRect(x, y, BLOCK_SIZE, BLOCK_SIZE);
+      }
+    }
+  };
+
+  // 在两点之间插值绘制马赛克（让线条连续）
+  const drawMosaicLine = (ctx: Taro.CanvasContext, from: Point, to: Point) => {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    const steps = Math.max(1, Math.floor(distance / (BLOCK_SIZE / 2)));
+
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const point = {
+        x: from.x + dx * t,
+        y: from.y + dy * t,
+      };
+      drawMosaicAt(ctx, point);
+    }
+  };
+
   const handleTouchStart = (e: { touches: { x: number; y: number }[] }) => {
     const touch = e.touches[0];
-    setSelecting(true);
-    setStartPoint({ x: touch.x, y: touch.y });
-    setCurrentRect(null);
+    const point = { x: touch.x, y: touch.y };
+
+    vibrateLight();
+    setDrawing(true);
+    currentStrokeRef.current = [point];
+    lastPointRef.current = point;
+
+    // 立即绘制当前点
+    const ctx = Taro.createCanvasContext(canvasRef.current);
+    ctx.drawImage(imageUrl, 0, 0, canvasSize.width, canvasSize.height);
+
+    // 绘制历史笔画
+    strokeHistory.forEach((stroke) => {
+      for (let i = 0; i < stroke.length; i++) {
+        if (i === 0) {
+          drawMosaicAt(ctx, stroke[i]);
+        } else {
+          drawMosaicLine(ctx, stroke[i - 1], stroke[i]);
+        }
+      }
+    });
+
+    // 绘制当前点
+    drawMosaicAt(ctx, point);
+    ctx.draw();
   };
 
   const handleTouchMove = (e: { touches: { x: number; y: number }[] }) => {
-    if (!selecting) return;
+    if (!drawing) return;
 
     const touch = e.touches[0];
-    const rect: Rect = {
-      x: Math.min(startPoint.x, touch.x),
-      y: Math.min(startPoint.y, touch.y),
-      width: Math.abs(touch.x - startPoint.x),
-      height: Math.abs(touch.y - startPoint.y),
-    };
-    setCurrentRect(rect);
+    const point = { x: touch.x, y: touch.y };
+    currentStrokeRef.current.push(point);
+
+    const ctx = Taro.createCanvasContext(canvasRef.current);
+    ctx.drawImage(imageUrl, 0, 0, canvasSize.width, canvasSize.height);
+
+    // 绘制历史笔画
+    strokeHistory.forEach((stroke) => {
+      for (let i = 0; i < stroke.length; i++) {
+        if (i === 0) {
+          drawMosaicAt(ctx, stroke[i]);
+        } else {
+          drawMosaicLine(ctx, stroke[i - 1], stroke[i]);
+        }
+      }
+    });
+
+    // 绘制当前笔画
+    const currentStroke = currentStrokeRef.current;
+    for (let i = 0; i < currentStroke.length; i++) {
+      if (i === 0) {
+        drawMosaicAt(ctx, currentStroke[i]);
+      } else {
+        drawMosaicLine(ctx, currentStroke[i - 1], currentStroke[i]);
+      }
+    }
+
+    ctx.draw();
+    lastPointRef.current = point;
   };
 
   const handleTouchEnd = () => {
-    setSelecting(false);
-    if (currentRect && currentRect.width > 10 && currentRect.height > 10) {
-      setMosaicRects([...mosaicRects, currentRect]);
-      applyMosaic(currentRect);
+    if (!drawing) return;
+
+    setDrawing(false);
+
+    // 保存当前笔画到历史
+    if (currentStrokeRef.current.length > 0) {
+      setStrokeHistory([...strokeHistory, [...currentStrokeRef.current]]);
     }
-    setCurrentRect(null);
+
+    currentStrokeRef.current = [];
+    lastPointRef.current = null;
   };
 
-  const applyMosaic = (rect: Rect) => {
+  const redrawAllStrokes = (strokes: Point[][]) => {
     const ctx = Taro.createCanvasContext(canvasRef.current);
-
-    // 重绘图片
     ctx.drawImage(imageUrl, 0, 0, canvasSize.width, canvasSize.height);
 
-    // 对所有已有区域和新区域应用马赛克
-    const allRects = [...mosaicRects, rect];
-    allRects.forEach((r) => {
-      // 用灰色方块模拟马赛克效果
-      const blockSize = 10;
-      for (let x = r.x; x < r.x + r.width; x += blockSize) {
-        for (let y = r.y; y < r.y + r.height; y += blockSize) {
-          // 随机灰度色
-          const gray = Math.floor(Math.random() * 100) + 100;
-          ctx.setFillStyle(`rgb(${gray}, ${gray}, ${gray})`);
-          ctx.fillRect(x, y, blockSize, blockSize);
+    strokes.forEach((stroke) => {
+      for (let i = 0; i < stroke.length; i++) {
+        if (i === 0) {
+          drawMosaicAt(ctx, stroke[i]);
+        } else {
+          drawMosaicLine(ctx, stroke[i - 1], stroke[i]);
         }
       }
     });
@@ -135,26 +222,22 @@ export default function MosaicEditor() {
   };
 
   const handleUndo = () => {
-    if (mosaicRects.length === 0) return;
+    if (strokeHistory.length === 0) return;
+    vibrateLight();
 
-    const newRects = mosaicRects.slice(0, -1);
-    setMosaicRects(newRects);
+    const newHistory = strokeHistory.slice(0, -1);
+    setStrokeHistory(newHistory);
+    redrawAllStrokes(newHistory);
+  };
 
-    // 重绘
+  const handleClearAll = () => {
+    if (strokeHistory.length === 0) return;
+    vibrateLight();
+
+    setStrokeHistory([]);
+    // 重绘原图
     const ctx = Taro.createCanvasContext(canvasRef.current);
     ctx.drawImage(imageUrl, 0, 0, canvasSize.width, canvasSize.height);
-
-    newRects.forEach((r) => {
-      const blockSize = 10;
-      for (let x = r.x; x < r.x + r.width; x += blockSize) {
-        for (let y = r.y; y < r.y + r.height; y += blockSize) {
-          const gray = Math.floor(Math.random() * 100) + 100;
-          ctx.setFillStyle(`rgb(${gray}, ${gray}, ${gray})`);
-          ctx.fillRect(x, y, blockSize, blockSize);
-        }
-      }
-    });
-
     ctx.draw();
   };
 
@@ -234,23 +317,24 @@ export default function MosaicEditor() {
               onTouchEnd={handleTouchEnd}
             />
           )}
-          {currentRect && (
-            <View
-              className="selection-rect"
-              style={{
-                left: `${currentRect.x}px`,
-                top: `${currentRect.y}px`,
-                width: `${currentRect.width}px`,
-                height: `${currentRect.height}px`,
-              }}
-            />
+          {/* 涂抹提示 - 无涂抹时显示 */}
+          {strokeHistory.length === 0 && !drawing && (
+            <View className="select-hint">
+              <Text className="select-hint-text">用手指涂抹敏感信息</Text>
+            </View>
           )}
         </View>
       </View>
 
       <View className="action-bar">
         <View
-          className={`action-btn undo-btn ${mosaicRects.length === 0 ? "disabled" : ""}`}
+          className={`action-btn secondary-btn ${strokeHistory.length === 0 ? "disabled" : ""}`}
+          onClick={handleClearAll}
+        >
+          清除
+        </View>
+        <View
+          className={`action-btn secondary-btn ${strokeHistory.length === 0 ? "disabled" : ""}`}
           onClick={handleUndo}
         >
           撤销


### PR DESCRIPTION
## Summary
- Replace box selection with brush-style painting for more intuitive touch interaction
- Add line interpolation to ensure smooth, continuous strokes when painting quickly
- Add haptic feedback when starting to paint
- Add "clear all" button to reset alongside the existing undo function
- Show guidance text "用手指涂抹敏感信息" when canvas is empty

## Test plan
- [ ] Open mosaic editor from labtest or exam image upload
- [ ] Paint over text with finger and verify mosaic appears smoothly
- [ ] Verify undo removes the last stroke
- [ ] Verify clear removes all strokes
- [ ] Confirm and verify the processed image is returned correctly

🤖 Generated with [Claude Code](https://claude.ai/code)