### PR TITLE
fix(privacy): update GitHub repo URL to omygut/mygut

### DIFF
--- a/src/pages/privacy/index.tsx
+++ b/src/pages/privacy/index.tsx
@@ -57,7 +57,7 @@ export default function Privacy() {
       <View className="section">
         <Text className="section-title">开源代码</Text>
         <Text className="section-content">
-          本项目完全开源，您可以在 GitHub 查看源代码：github.com/fankaidev/mygut
+          本项目完全开源，您可以在 GitHub 查看源代码：github.com/omygut/mygut
         </Text>
       </View>
 


### PR DESCRIPTION
## Summary
- Update the GitHub repository URL in privacy policy page from `fankaidev/mygut` to `omygut/mygut`

## Test plan
- [ ] Verify privacy page displays correct repo URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)