### PR TITLE
fix(profile): prevent avatar reset when choosing new image

### DIFF
--- a/src/components/ProfilePopup/index.tsx
+++ b/src/components/ProfilePopup/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { View, Text, Image, Input, Button } from "@tarojs/components";
 import Taro from "@tarojs/taro";
 import { updateUserSettings, uploadAvatar } from "../../services/user";
@@ -24,13 +24,16 @@ export default function ProfilePopup({
   const [currentAvatar, setCurrentAvatar] = useState(avatar);
   const [tempAvatarPath, setTempAvatarPath] = useState<string>();
   const [saving, setSaving] = useState(false);
+  const prevVisibleRef = useRef(visible);
 
   useEffect(() => {
-    if (visible) {
+    // 只在弹窗打开时（visible 从 false 变为 true）初始化状态
+    if (visible && !prevVisibleRef.current) {
       setCurrentNickname(nickname);
       setCurrentAvatar(avatar);
       setTempAvatarPath(undefined);
     }
+    prevVisibleRef.current = visible;
   }, [visible, nickname, avatar]);
 
   if (!visible) return null;

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,7 +1,8 @@
 import { View, Text, Image } from "@tarojs/components";
 import Taro, { useDidShow } from "@tarojs/taro";
 import { useState, useCallback } from "react";
-import { getUserSettings } from "../../services/user";
+import { getUserSettings, getDefaultNickname } from "../../services/user";
+import ProfilePopup from "../../components/ProfilePopup";
 import "./index.css";
 
 export default function Index() {
@@ -10,6 +11,7 @@ export default function Index() {
     nickname?: string;
     avatar?: string;
   } | null>(null);
+  const [showProfilePopup, setShowProfilePopup] = useState(false);
 
   const loadUserSettings = useCallback(async () => {
     try {
@@ -28,6 +30,22 @@ export default function Index() {
     Taro.navigateTo({ url: path });
   };
 
+  const handleAvatarClick = () => {
+    setShowProfilePopup(true);
+  };
+
+  const handleProfileClose = () => {
+    setShowProfilePopup(false);
+  };
+
+  const handleProfileSave = (data: { nickname: string; avatar?: string }) => {
+    setUserSettings((prev) => (prev ? { ...prev, ...data } : prev));
+    setShowProfilePopup(false);
+  };
+
+  const displayNickname =
+    userSettings?.nickname || (userSettings?._id ? getDefaultNickname(userSettings._id) : "");
+
   return (
     <View className="home-page">
       <View className="top-header">
@@ -35,13 +53,21 @@ export default function Index() {
           <Text className="app-title">MyGut</Text>
           <Text className="app-subtitle">肠道健康记录</Text>
         </View>
-        <View className="header-avatar">
+        <View className="header-avatar" onClick={handleAvatarClick}>
           {userSettings?.avatar ? (
             <Image className="avatar-img" src={userSettings.avatar} mode="aspectFill" />
           ) : (
             <View className="avatar-default" />
           )}
         </View>
+
+        <ProfilePopup
+          visible={showProfilePopup}
+          nickname={displayNickname}
+          avatar={userSettings?.avatar}
+          onClose={handleProfileClose}
+          onSave={handleProfileSave}
+        />
       </View>
 
       <View className="quick-actions">


### PR DESCRIPTION
## Problem
When selecting a new avatar image, it briefly shows then reverts to the old image.

## Cause
The `useEffect` was resetting state whenever `avatar` prop changed, not just when popup opens.

## Solution
Track previous `visible` state and only initialize when popup opens (visible changes from false to true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)