### PR TITLE
feat(records): add calendar popup for date selection

### DIFF
--- a/src/components/CalendarPopup/index.css
+++ b/src/components/CalendarPopup/index.css
@@ -1,0 +1,93 @@
+.calendar-popup-mask {
+  position: fixed;
+  inset: 0;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.calendar-popup {
+  width: 90%;
+  max-width: 640px;
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 24px;
+}
+
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.calendar-nav {
+  font-size: 32px;
+  color: #07c160;
+  padding: 16px;
+}
+
+.calendar-nav.disabled {
+  color: #ccc;
+}
+
+.calendar-title {
+  font-size: 32px;
+  font-weight: 600;
+  color: #333;
+}
+
+.calendar-weekdays {
+  display: flex;
+  margin-bottom: 16px;
+}
+
+.calendar-weekday {
+  flex: 1;
+  text-align: center;
+  font-size: 24px;
+  color: #999;
+}
+
+.calendar-days {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.calendar-day {
+  width: 14.28%;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.calendar-day.empty {
+  visibility: hidden;
+}
+
+.calendar-day.future {
+  opacity: 0.3;
+}
+
+.day-text {
+  width: 64px;
+  height: 64px;
+  line-height: 64px;
+  text-align: center;
+  font-size: 28px;
+  color: #333;
+  border-radius: 50%;
+}
+
+.calendar-day.today .day-text {
+  color: #07c160;
+  font-weight: 600;
+}
+
+.calendar-day.selected .day-text {
+  background-color: #07c160;
+  color: #fff;
+}

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -1,0 +1,163 @@
+import { View, Text } from "@tarojs/components";
+import { useState, useEffect } from "react";
+import { formatDate } from "../../utils/date";
+import "./index.css";
+
+interface CalendarPopupProps {
+  visible: boolean;
+  value: string; // YYYY-MM-DD
+  onChange: (date: string) => void;
+  onClose: () => void;
+}
+
+const WEEKDAYS = ["日", "一", "二", "三", "四", "五", "六"];
+
+// 获取某月的天数
+function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+// 获取某月第一天是星期几
+function getFirstDayOfMonth(year: number, month: number): number {
+  return new Date(year, month, 1).getDay();
+}
+
+// 生成日历网格数据
+function generateCalendarDays(year: number, month: number): (number | null)[] {
+  const daysInMonth = getDaysInMonth(year, month);
+  const firstDay = getFirstDayOfMonth(year, month);
+
+  const days: (number | null)[] = [];
+
+  // 前面的空白
+  for (let i = 0; i < firstDay; i++) {
+    days.push(null);
+  }
+
+  // 当月的天数
+  for (let i = 1; i <= daysInMonth; i++) {
+    days.push(i);
+  }
+
+  return days;
+}
+
+export default function CalendarPopup({ visible, value, onChange, onClose }: CalendarPopupProps) {
+  const today = formatDate();
+  const [viewYear, setViewYear] = useState(() => parseInt(value.slice(0, 4)));
+  const [viewMonth, setViewMonth] = useState(() => parseInt(value.slice(5, 7)) - 1);
+
+  // 当 value 改变时，更新视图月份
+  useEffect(() => {
+    setViewYear(parseInt(value.slice(0, 4)));
+    setViewMonth(parseInt(value.slice(5, 7)) - 1);
+  }, [value]);
+
+  if (!visible) return null;
+
+  const days = generateCalendarDays(viewYear, viewMonth);
+
+  const handlePrevMonth = () => {
+    if (viewMonth === 0) {
+      setViewYear(viewYear - 1);
+      setViewMonth(11);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  };
+
+  const handleNextMonth = () => {
+    const todayYear = parseInt(today.slice(0, 4));
+    const todayMonth = parseInt(today.slice(5, 7)) - 1;
+
+    // 不能超过今天所在月份
+    if (viewYear > todayYear || (viewYear === todayYear && viewMonth >= todayMonth)) {
+      return;
+    }
+
+    if (viewMonth === 11) {
+      setViewYear(viewYear + 1);
+      setViewMonth(0);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  };
+
+  const handleDayClick = (day: number | null) => {
+    if (day === null) return;
+
+    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+
+    // 不能选择未来的日期
+    if (dateStr > today) return;
+
+    onChange(dateStr);
+    onClose();
+  };
+
+  const isToday = (day: number | null): boolean => {
+    if (day === null) return false;
+    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    return dateStr === today;
+  };
+
+  const isSelected = (day: number | null): boolean => {
+    if (day === null) return false;
+    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    return dateStr === value;
+  };
+
+  const isFuture = (day: number | null): boolean => {
+    if (day === null) return false;
+    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    return dateStr > today;
+  };
+
+  const todayYear = parseInt(today.slice(0, 4));
+  const todayMonth = parseInt(today.slice(5, 7)) - 1;
+  const isCurrentMonth = viewYear === todayYear && viewMonth === todayMonth;
+
+  return (
+    <View className="calendar-popup-mask" onClick={onClose}>
+      <View className="calendar-popup" onClick={(e) => e.stopPropagation()}>
+        {/* 月份标题 */}
+        <View className="calendar-header">
+          <Text className="calendar-nav" onClick={handlePrevMonth}>
+            ◀
+          </Text>
+          <Text className="calendar-title">
+            {viewYear}年{viewMonth + 1}月
+          </Text>
+          <Text
+            className={`calendar-nav ${isCurrentMonth ? "disabled" : ""}`}
+            onClick={handleNextMonth}
+          >
+            ▶
+          </Text>
+        </View>
+
+        {/* 星期标题 */}
+        <View className="calendar-weekdays">
+          {WEEKDAYS.map((day) => (
+            <Text key={day} className="calendar-weekday">
+              {day}
+            </Text>
+          ))}
+        </View>
+
+        {/* 日期网格 */}
+        <View className="calendar-days">
+          {days.map((day, index) => (
+            <View
+              key={index}
+              className={`calendar-day ${day === null ? "empty" : ""} ${isToday(day) ? "today" : ""} ${isSelected(day) ? "selected" : ""} ${isFuture(day) ? "future" : ""}`}
+              onClick={() => handleDayClick(day)}
+            >
+              {day !== null && <Text className="day-text">{day}</Text>}
+            </View>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/pages/records/index.tsx
+++ b/src/pages/records/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Picker } from "@tarojs/components";
+import { View, Text } from "@tarojs/components";
 import Taro, { useDidShow } from "@tarojs/taro";
 import { useState, useCallback } from "react";
 import { symptomService } from "../../services/symptom";
@@ -13,6 +13,7 @@ import { SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
 import { AMOUNT_OPTIONS } from "../../constants/meal";
 import { STOOL_AMOUNTS } from "../../constants/stool";
 import BristolIcon from "../../components/BristolIcon";
+import CalendarPopup from "../../components/CalendarPopup";
 import type {
   SymptomRecord,
   MealRecord,
@@ -51,6 +52,7 @@ const getExamTypeInfo = (examType: string) => {
 export default function Records() {
   const [currentDate, setCurrentDate] = useState(formatDate());
   const [loading, setLoading] = useState(true);
+  const [calendarVisible, setCalendarVisible] = useState(false);
   const [symptomRecords, setSymptomRecords] = useState<SymptomRecord[]>([]);
   const [mealRecords, setMealRecords] = useState<MealRecord[]>([]);
   const [stoolRecords, setStoolRecords] = useState<StoolRecord[]>([]);
@@ -103,8 +105,7 @@ export default function Records() {
     loadData(newDate);
   };
 
-  const handleDateChange = (e: { detail: { value: string } }) => {
-    const newDate = e.detail.value;
+  const handleDateChange = (newDate: string) => {
     setCurrentDate(newDate);
     loadData(newDate);
   };
@@ -120,15 +121,20 @@ export default function Records() {
         <Text className="date-arrow" onClick={handlePrevDate}>
           ◀
         </Text>
-        <Picker mode="date" value={currentDate} end={today} onChange={handleDateChange}>
-          <Text className="date-text">
-            {currentDate} {getWeekday(currentDate)}
-          </Text>
-        </Picker>
+        <Text className="date-text" onClick={() => setCalendarVisible(true)}>
+          {currentDate} {getWeekday(currentDate)}
+        </Text>
         <Text className={`date-arrow ${isToday ? "disabled" : ""}`} onClick={handleNextDate}>
           ▶
         </Text>
       </View>
+
+      <CalendarPopup
+        visible={calendarVisible}
+        value={currentDate}
+        onChange={handleDateChange}
+        onClose={() => setCalendarVisible(false)}
+      />
 
       {loading ? (
         <View className="loading">加载中...</View>


### PR DESCRIPTION
## Summary
- Create `CalendarPopup` component with monthly calendar view
- Replace Picker with calendar popup on date page
- Click date text to open calendar, click day to select
- Keep left/right arrows for quick day navigation
- Highlight today (green text) and selected date (green background)
- Disable future dates

## New component
`src/components/CalendarPopup/` - reusable calendar popup with props:
- `visible`: show/hide popup
- `value`: selected date (YYYY-MM-DD)
- `onChange`: callback when date selected
- `onClose`: callback when popup closed

Closes #103

## Test plan
- [ ] Click date text to open calendar popup
- [ ] Verify current month displays correctly
- [ ] Click prev/next to navigate months (cannot go past current month)
- [ ] Select a date and verify it updates
- [ ] Verify today is highlighted, selected date has green background
- [ ] Verify future dates are disabled

🤖 Generated with [Claude Code](https://claude.ai/code)