### PR TITLE
fix(profile): add timestamp to avatar URL to prevent caching

### DIFF
--- a/src/components/ProfilePopup/index.tsx
+++ b/src/components/ProfilePopup/index.tsx
@@ -81,9 +81,14 @@ export default function ProfilePopup({
         ...(avatarToSave && { avatar: avatarToSave }),
       });
 
+      // 给 URL 加时间戳防止缓存
+      const avatarWithTimestamp = avatarToDisplay
+        ? `${avatarToDisplay}${avatarToDisplay.includes("?") ? "&" : "?"}_t=${Date.now()}`
+        : avatarToDisplay;
+
       onSave({
         nickname: currentNickname.trim(),
-        avatar: avatarToDisplay,
+        avatar: avatarWithTimestamp,
       });
 
       Taro.showToast({ title: "保存成功", icon: "success" });


### PR DESCRIPTION
## Summary
- Add timestamp parameter to avatar URL after upload to prevent WeChat Image component from showing cached images
- Since avatar uploads use a fixed path (`avatar.jpg`), the base URL stays the same even after content changes
- The timestamp makes each URL unique, forcing a fresh fetch

## Test plan
- [ ] Upload a new avatar image
- [ ] Verify the new image displays immediately after save
- [ ] Close and reopen the profile popup, verify the new avatar persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)