### PR TITLE
feat(form): use CalendarPopup for date selection in all form pages

### DIFF
--- a/src/components/CalendarPopup/index.css
+++ b/src/components/CalendarPopup/index.css
@@ -3,17 +3,17 @@
   inset: 0;
   background-color: rgb(0 0 0 / 50%);
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
   z-index: 1000;
 }
 
 .calendar-popup {
-  width: 90%;
-  max-width: 640px;
+  width: 100%;
   background-color: #fff;
-  border-radius: 16px;
+  border-radius: 24px 24px 0 0;
   padding: 24px;
+  padding-bottom: calc(24px + env(safe-area-inset-bottom));
 }
 
 .calendar-header {
@@ -52,24 +52,16 @@
 }
 
 .calendar-days {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-rows: repeat(6, 1fr);
 }
 
 .calendar-day {
-  width: 14.28%;
   aspect-ratio: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.calendar-day.empty {
-  visibility: hidden;
-}
-
-.calendar-day.future {
-  opacity: 0.3;
 }
 
 .day-text {
@@ -80,6 +72,11 @@
   font-size: 28px;
   color: #333;
   border-radius: 50%;
+}
+
+.calendar-day.other-month .day-text,
+.calendar-day.future .day-text {
+  color: #ccc;
 }
 
 .calendar-day.today .day-text {

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -22,21 +22,54 @@ function getFirstDayOfMonth(year: number, month: number): number {
   return new Date(year, month, 1).getDay();
 }
 
-// 生成日历网格数据
-function generateCalendarDays(year: number, month: number): (number | null)[] {
+interface DayInfo {
+  day: number;
+  isCurrentMonth: boolean;
+  dateStr: string;
+}
+
+// 生成日历网格数据（固定 42 格 = 6 行）
+function generateCalendarDays(year: number, month: number): DayInfo[] {
   const daysInMonth = getDaysInMonth(year, month);
   const firstDay = getFirstDayOfMonth(year, month);
 
-  const days: (number | null)[] = [];
+  const days: DayInfo[] = [];
 
-  // 前面的空白
-  for (let i = 0; i < firstDay; i++) {
-    days.push(null);
+  // 前面补上个月的日期
+  if (firstDay > 0) {
+    const prevMonth = month === 0 ? 11 : month - 1;
+    const prevYear = month === 0 ? year - 1 : year;
+    const prevMonthDays = getDaysInMonth(prevYear, prevMonth);
+    for (let i = firstDay - 1; i >= 0; i--) {
+      const day = prevMonthDays - i;
+      days.push({
+        day,
+        isCurrentMonth: false,
+        dateStr: `${prevYear}-${String(prevMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+      });
+    }
   }
 
   // 当月的天数
   for (let i = 1; i <= daysInMonth; i++) {
-    days.push(i);
+    days.push({
+      day: i,
+      isCurrentMonth: true,
+      dateStr: `${year}-${String(month + 1).padStart(2, "0")}-${String(i).padStart(2, "0")}`,
+    });
+  }
+
+  // 后面补下个月的日期
+  const nextMonth = month === 11 ? 0 : month + 1;
+  const nextYear = month === 11 ? year + 1 : year;
+  let nextDay = 1;
+  while (days.length < 42) {
+    days.push({
+      day: nextDay,
+      isCurrentMonth: false,
+      dateStr: `${nextYear}-${String(nextMonth + 1).padStart(2, "0")}-${String(nextDay).padStart(2, "0")}`,
+    });
+    nextDay++;
   }
 
   return days;
@@ -83,34 +116,12 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
     }
   };
 
-  const handleDayClick = (day: number | null) => {
-    if (day === null) return;
-
-    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-
+  const handleDayClick = (dayInfo: DayInfo) => {
     // 不能选择未来的日期
-    if (dateStr > today) return;
+    if (dayInfo.dateStr > today) return;
 
-    onChange(dateStr);
+    onChange(dayInfo.dateStr);
     onClose();
-  };
-
-  const isToday = (day: number | null): boolean => {
-    if (day === null) return false;
-    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-    return dateStr === today;
-  };
-
-  const isSelected = (day: number | null): boolean => {
-    if (day === null) return false;
-    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-    return dateStr === value;
-  };
-
-  const isFuture = (day: number | null): boolean => {
-    if (day === null) return false;
-    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-    return dateStr > today;
   };
 
   const todayYear = parseInt(today.slice(0, 4));
@@ -147,13 +158,13 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
 
         {/* 日期网格 */}
         <View className="calendar-days">
-          {days.map((day, index) => (
+          {days.map((dayInfo, index) => (
             <View
               key={index}
-              className={`calendar-day ${day === null ? "empty" : ""} ${isToday(day) ? "today" : ""} ${isSelected(day) ? "selected" : ""} ${isFuture(day) ? "future" : ""}`}
-              onClick={() => handleDayClick(day)}
+              className={`calendar-day ${!dayInfo.isCurrentMonth ? "other-month" : ""} ${dayInfo.dateStr === today ? "today" : ""} ${dayInfo.dateStr === value ? "selected" : ""} ${dayInfo.dateStr > today ? "future" : ""}`}
+              onClick={() => handleDayClick(dayInfo)}
             >
-              {day !== null && <Text className="day-text">{day}</Text>}
+              <Text className="day-text">{dayInfo.day}</Text>
             </View>
           ))}
         </View>

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -31,23 +31,26 @@ interface DayInfo {
 // 生成日历网格数据（固定 42 格 = 6 行）
 function generateCalendarDays(year: number, month: number): DayInfo[] {
   const daysInMonth = getDaysInMonth(year, month);
-  const firstDay = getFirstDayOfMonth(year, month);
+  let firstDay = getFirstDayOfMonth(year, month);
+
+  // 如果当月1号是周日（firstDay=0），则显示上周整周，确保第一行有上个月日期
+  if (firstDay === 0) {
+    firstDay = 7;
+  }
 
   const days: DayInfo[] = [];
 
   // 前面补上个月的日期
-  if (firstDay > 0) {
-    const prevMonth = month === 0 ? 11 : month - 1;
-    const prevYear = month === 0 ? year - 1 : year;
-    const prevMonthDays = getDaysInMonth(prevYear, prevMonth);
-    for (let i = firstDay - 1; i >= 0; i--) {
-      const day = prevMonthDays - i;
-      days.push({
-        day,
-        isCurrentMonth: false,
-        dateStr: `${prevYear}-${String(prevMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
-      });
-    }
+  const prevMonth = month === 0 ? 11 : month - 1;
+  const prevYear = month === 0 ? year - 1 : year;
+  const prevMonthDays = getDaysInMonth(prevYear, prevMonth);
+  for (let i = firstDay - 1; i >= 0; i--) {
+    const day = prevMonthDays - i;
+    days.push({
+      day,
+      isCurrentMonth: false,
+      dateStr: `${prevYear}-${String(prevMonth + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+    });
   }
 
   // 当月的天数

--- a/src/pages/exam/add/index.tsx
+++ b/src/pages/exam/add/index.tsx
@@ -6,6 +6,7 @@ import { recognizeExamReport } from "../../../services/ai";
 import { chooseImage, uploadImage, deleteCloudFile } from "../../../utils/upload";
 import { formatDate } from "../../../utils/date";
 import { EXAM_TYPES } from "../../../constants/exam";
+import CalendarPopup from "../../../components/CalendarPopup";
 import "./index.css";
 
 export default function ExamAdd() {
@@ -15,7 +16,9 @@ export default function ExamAdd() {
 
   const [date, setDate] = useState(formatDate());
   const [time, setTime] = useState("10:00");
-  const [examType, setExamType] = useState<(typeof EXAM_TYPES)[number]["value"]>(EXAM_TYPES[0].value);
+  const [examType, setExamType] = useState<(typeof EXAM_TYPES)[number]["value"]>(
+    EXAM_TYPES[0].value,
+  );
   const [content, setContent] = useState("");
   const [note, setNote] = useState("");
   const [localImages, setLocalImages] = useState<string[]>([]);
@@ -23,6 +26,7 @@ export default function ExamAdd() {
   const [submitting, setSubmitting] = useState(false);
   const [recognizing, setRecognizing] = useState(false);
   const [loading, setLoading] = useState(isEdit);
+  const [calendarVisible, setCalendarVisible] = useState(false);
 
   const localImagesRef = useRef(localImages);
   localImagesRef.current = localImages;
@@ -241,13 +245,19 @@ export default function ExamAdd() {
       <View className="section">
         <Text className="section-title">时间</Text>
         <View className="time-row">
-          <Picker mode="date" value={date} onChange={(e) => setDate(e.detail.value)}>
-            <View className="picker-value">{date}</View>
-          </Picker>
+          <View className="picker-value" onClick={() => setCalendarVisible(true)}>
+            {date}
+          </View>
           <Picker mode="time" value={time} onChange={(e) => setTime(e.detail.value)}>
             <View className="picker-value">{time}</View>
           </Picker>
         </View>
+        <CalendarPopup
+          visible={calendarVisible}
+          value={date}
+          onChange={setDate}
+          onClose={() => setCalendarVisible(false)}
+        />
       </View>
 
       {/* 检查类型 */}

--- a/src/pages/labtest/add/index.tsx
+++ b/src/pages/labtest/add/index.tsx
@@ -6,6 +6,7 @@ import { recognizeLabTestImage } from "../../../services/ai";
 import { normalizeIndicators, type SpecimenType } from "../../../services/labtest-standards";
 import { chooseImage, uploadImage, deleteCloudFile } from "../../../utils/upload";
 import { formatDate, formatTime } from "../../../utils/date";
+import CalendarPopup from "../../../components/CalendarPopup";
 import type { LabTestIndicator } from "../../../types";
 import "./index.css";
 
@@ -32,6 +33,7 @@ export default function LabTestAdd() {
   const [recognizing, setRecognizing] = useState(false);
   const [indicators, setIndicators] = useState<LabTestIndicator[]>([]);
   const [loading, setLoading] = useState(isEdit);
+  const [calendarVisible, setCalendarVisible] = useState(false);
 
   const localImagesRef = useRef(localImages);
   localImagesRef.current = localImages;
@@ -258,13 +260,19 @@ export default function LabTestAdd() {
       <View className="section">
         <Text className="section-title">时间</Text>
         <View className="time-row">
-          <Picker mode="date" value={date} onChange={(e) => setDate(e.detail.value)}>
-            <View className="picker-value">{date}</View>
-          </Picker>
+          <View className="picker-value" onClick={() => setCalendarVisible(true)}>
+            {date}
+          </View>
           <Picker mode="time" value={time} onChange={(e) => setTime(e.detail.value)}>
             <View className="picker-value">{time}</View>
           </Picker>
         </View>
+        <CalendarPopup
+          visible={calendarVisible}
+          value={date}
+          onChange={setDate}
+          onClose={() => setCalendarVisible(false)}
+        />
       </View>
 
       {/* 标本类型 */}

--- a/src/pages/meal/add/index.tsx
+++ b/src/pages/meal/add/index.tsx
@@ -5,6 +5,7 @@ import { mealService } from "../../../services/meal";
 import { FOOD_CATEGORIES, AMOUNT_OPTIONS } from "../../../constants/meal";
 import { formatDate, formatTime } from "../../../utils/date";
 import { validateFood } from "../../../utils/validation";
+import CalendarPopup from "../../../components/CalendarPopup";
 import "./index.css";
 
 const CUSTOM_FOODS_KEY = "custom_foods";
@@ -55,6 +56,7 @@ export default function MealAdd() {
   const [customFoods, setCustomFoods] = useState<string[]>([]);
   const [topFoods, setTopFoods] = useState<string[]>([]);
   const [loading, setLoading] = useState(isEdit);
+  const [calendarVisible, setCalendarVisible] = useState(false);
 
   useEffect(() => {
     if (editId) {
@@ -218,13 +220,19 @@ export default function MealAdd() {
       <View className="section">
         <Text className="section-title">时间</Text>
         <View className="time-row">
-          <Picker mode="date" value={date} onChange={(e) => setDate(e.detail.value)}>
-            <View className="picker-value">{date}</View>
-          </Picker>
+          <View className="picker-value" onClick={() => setCalendarVisible(true)}>
+            {date}
+          </View>
           <Picker mode="time" value={time} onChange={(e) => setTime(e.detail.value)}>
             <View className="picker-value">{time}</View>
           </Picker>
         </View>
+        <CalendarPopup
+          visible={calendarVisible}
+          value={date}
+          onChange={setDate}
+          onClose={() => setCalendarVisible(false)}
+        />
       </View>
 
       {/* 食物选择 */}

--- a/src/pages/medication/add/index.tsx
+++ b/src/pages/medication/add/index.tsx
@@ -5,6 +5,7 @@ import { medicationService } from "../../../services/medication";
 import { MEDICATION_CATEGORIES } from "../../../constants/medication";
 import { formatDate, formatTime } from "../../../utils/date";
 import { validateMedication } from "../../../utils/validation";
+import CalendarPopup from "../../../components/CalendarPopup";
 import "./index.css";
 
 const CUSTOM_MEDICATIONS_KEY = "custom_medications";
@@ -47,6 +48,7 @@ export default function MedicationAdd() {
   const [customMedications, setCustomMedications] = useState<string[]>([]);
   const [topMedications, setTopMedications] = useState<string[]>([]);
   const [loading, setLoading] = useState(isEdit);
+  const [calendarVisible, setCalendarVisible] = useState(false);
 
   useEffect(() => {
     if (editId) {
@@ -207,13 +209,19 @@ export default function MedicationAdd() {
       <View className="section">
         <Text className="section-title">时间</Text>
         <View className="time-row">
-          <Picker mode="date" value={date} onChange={(e) => setDate(e.detail.value)}>
-            <View className="picker-value">{date}</View>
-          </Picker>
+          <View className="picker-value" onClick={() => setCalendarVisible(true)}>
+            {date}
+          </View>
           <Picker mode="time" value={time} onChange={(e) => setTime(e.detail.value)}>
             <View className="picker-value">{time}</View>
           </Picker>
         </View>
+        <CalendarPopup
+          visible={calendarVisible}
+          value={date}
+          onChange={setDate}
+          onClose={() => setCalendarVisible(false)}
+        />
       </View>
 
       {/* 药物选择 */}

--- a/src/pages/stool/add/index.tsx
+++ b/src/pages/stool/add/index.tsx
@@ -5,6 +5,7 @@ import { stoolService } from "../../../services/stool";
 import { BRISTOL_TYPES, STOOL_AMOUNTS, NOTE_SHORTCUTS } from "../../../constants/stool";
 import { formatDate, formatTime } from "../../../utils/date";
 import BristolIcon from "../../../components/BristolIcon";
+import CalendarPopup from "../../../components/CalendarPopup";
 import type { StoolRecord } from "../../../types";
 import "./index.css";
 
@@ -20,6 +21,7 @@ export default function StoolAdd() {
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [loading, setLoading] = useState(isEdit);
+  const [calendarVisible, setCalendarVisible] = useState(false);
 
   useEffect(() => {
     if (editId) {
@@ -112,13 +114,19 @@ export default function StoolAdd() {
       <View className="section">
         <Text className="section-title">时间</Text>
         <View className="time-row">
-          <Picker mode="date" value={date} onChange={(e) => setDate(e.detail.value)}>
-            <View className="picker-value">{date}</View>
-          </Picker>
+          <View className="picker-value" onClick={() => setCalendarVisible(true)}>
+            {date}
+          </View>
           <Picker mode="time" value={time} onChange={(e) => setTime(e.detail.value)}>
             <View className="picker-value">{time}</View>
           </Picker>
         </View>
+        <CalendarPopup
+          visible={calendarVisible}
+          value={date}
+          onChange={setDate}
+          onClose={() => setCalendarVisible(false)}
+        />
       </View>
 
       {/* Bristol 类型 */}

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -5,6 +5,7 @@ import { symptomService } from "../../../services/symptom";
 import { SYMPTOM_SHORTCUTS, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../../constants/symptom";
 import { formatDate, formatTime } from "../../../utils/date";
 import { validateSymptom } from "../../../utils/validation";
+import CalendarPopup from "../../../components/CalendarPopup";
 import type { SymptomRecord } from "../../../types";
 import "./index.css";
 
@@ -45,6 +46,7 @@ export default function SymptomAdd() {
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [loading, setLoading] = useState(isEdit);
+  const [calendarVisible, setCalendarVisible] = useState(false);
 
   useEffect(() => {
     if (editId) {
@@ -186,13 +188,19 @@ export default function SymptomAdd() {
       <View className="section">
         <Text className="section-title">时间</Text>
         <View className="time-row">
-          <Picker mode="date" value={date} onChange={(e) => setDate(e.detail.value)}>
-            <View className="picker-value">{date}</View>
-          </Picker>
+          <View className="picker-value" onClick={() => setCalendarVisible(true)}>
+            {date}
+          </View>
           <Picker mode="time" value={time} onChange={(e) => setTime(e.detail.value)}>
             <View className="picker-value">{time}</View>
           </Picker>
         </View>
+        <CalendarPopup
+          visible={calendarVisible}
+          value={date}
+          onChange={setDate}
+          onClose={() => setCalendarVisible(false)}
+        />
       </View>
 
       {/* 整体感受 */}


### PR DESCRIPTION
## Summary
- Replace native Picker with CalendarPopup in 6 form pages (stool, medication, labtest, exam, symptom, meal)
- Change calendar popup to bottom sheet style (slides up from bottom)
- Fix calendar height to 6 rows to prevent layout shift when switching months
- Show adjacent month dates in gray instead of blank cells

## Test plan
- [ ] Open each form page and verify date picker shows calendar popup from bottom
- [ ] Switch months and verify height remains constant
- [ ] Verify adjacent month dates display correctly in gray
- [ ] Select a date from previous/next month and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)