### PR TITLE
fix(deps): add nanoid for miniprogram-ci

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -16,6 +16,7 @@
     "@tarojs/vite-runner",
     "@vitejs/plugin-react",
     "miniprogram-ci",
+    "nanoid",
     "picocolors",
     "tsx",
     "vite"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lefthook": "^2.1.5",
     "miniprogram-automator": "^0.12.1",
     "miniprogram-ci": "^2.1.31",
+    "nanoid": "^3.3.11",
     "oxfmt": "^0.44.0",
     "oxlint": "^1.59.0",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       miniprogram-ci:
         specifier: ^2.1.31
         version: 2.1.31(eslint@8.41.0)
+      nanoid:
+        specifier: ^3.3.11
+        version: 3.3.11
       oxfmt:
         specifier: ^0.44.0
         version: 0.44.0


### PR DESCRIPTION
## Summary
- Add nanoid as explicit devDependency
- miniprogram-ci requires it through postcss but pnpm strict hoisting doesn't make it available
- Fixes CI build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)