### PR TITLE
fix(deps): add source-map-js for miniprogram-ci

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -18,6 +18,7 @@
     "miniprogram-ci",
     "nanoid",
     "picocolors",
+    "source-map-js",
     "tsx",
     "vite"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mygut",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "description": "MyGut - 肠道健康记录",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "oxlint": "^1.59.0",
     "picocolors": "^1.1.1",
     "postcss": "^8.5.6",
+    "source-map-js": "^1.2.1",
     "stylelint": "^16.4.0",
     "stylelint-config-standard": "^38.0.0",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       postcss:
         specifier: ^8.5.6
         version: 8.5.9
+      source-map-js:
+        specifier: ^1.2.1
+        version: 1.2.1
       stylelint:
         specifier: ^16.4.0
         version: 16.26.1(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- Add source-map-js as explicit devDependency
- miniprogram-ci requires it through postcss but pnpm strict hoisting doesn't make it available
- This completes the postcss peer deps: nanoid, picocolors, source-map-js
- Fixes CI build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)