### PR TITLE
feat(labtest): display test categories instead of indicator count

### DIFF
--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -1,6 +1,6 @@
 .record-item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   padding: 20px 24px;
   gap: 16px;
   border-bottom: 1px solid #f5f5f5;
@@ -38,6 +38,7 @@
   color: #333;
   flex: 1;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -138,13 +138,10 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
       case "exam": {
         const examTypeInfo = getExamTypeInfo(record.examType);
         return (
-          <>
-            <Text className="record-feeling">{examTypeInfo.emoji}</Text>
-            <Text className="record-desc">
-              {record.examName || examTypeInfo.label}
-              {record.imageFileIds.length > 0 && ` · ${record.imageFileIds.length}张图片`}
-            </Text>
-          </>
+          <Text className="record-desc">
+            {record.examName || examTypeInfo.label}
+            {record.imageFileIds.length > 0 && ` · ${record.imageFileIds.length}张图片`}
+          </Text>
         );
       }
     }

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -78,8 +78,8 @@ const getLabTestCategories = (indicators: LabTestIndicator[]): string => {
   const normalized = normalizeIndicators(indicators);
   const categories = [...new Set(normalized.map((i) => i.category).filter(Boolean))];
   if (categories.length === 0) return "";
-  if (categories.length <= 5) return categories.join("、");
-  return `${categories.slice(0, 5).join("、")}等${categories.length}类`;
+  if (categories.length <= 9) return categories.join("、");
+  return `${categories.slice(0, 9).join("、")}等${categories.length}类`;
 };
 
 export default function RecordItem({ record, showTypeIcon = false }: RecordItemProps) {

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -4,6 +4,7 @@ import { EXAM_TYPES } from "../../constants/exam";
 import { SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
 import { AMOUNT_OPTIONS } from "../../constants/meal";
 import { STOOL_AMOUNTS } from "../../constants/stool";
+import { normalizeIndicators } from "../../services/labtest-standards";
 import BristolIcon from "../BristolIcon";
 import type {
   SymptomRecord,
@@ -11,6 +12,7 @@ import type {
   StoolRecord,
   MedicationRecord,
   LabTestRecord,
+  LabTestIndicator,
   ExamRecord,
 } from "../../types";
 import "./index.css";
@@ -71,6 +73,15 @@ const getExamTypeInfo = (examType: string) => {
   return EXAM_TYPES.find((t) => t.value === examType) ?? { emoji: UNKNOWN, label: UNKNOWN };
 };
 
+const getLabTestCategories = (indicators: LabTestIndicator[]): string => {
+  if (indicators.length === 0) return "";
+  const normalized = normalizeIndicators(indicators);
+  const categories = [...new Set(normalized.map((i) => i.category).filter(Boolean))];
+  if (categories.length === 0) return "";
+  if (categories.length <= 5) return categories.join("、");
+  return `${categories.slice(0, 5).join("、")}等${categories.length}类`;
+};
+
 export default function RecordItem({ record, showTypeIcon = false }: RecordItemProps) {
   const handleClick = () => {
     const path = `${EDIT_PATHS[record._type]}?id=${record._id}`;
@@ -116,13 +127,14 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
             </Text>
           </>
         );
-      case "labtest":
+      case "labtest": {
+        const categoryText = getLabTestCategories(record.indicators);
         return (
           <Text className="record-desc">
-            {record.imageFileIds.length}张图片
-            {record.indicators.length > 0 && ` · ${record.indicators.length}项指标`}
+            {categoryText || `${record.imageFileIds.length}张图片`}
           </Text>
         );
+      }
       case "exam": {
         const examTypeInfo = getExamTypeInfo(record.examType);
         return (

--- a/src/constants/exam.ts
+++ b/src/constants/exam.ts
@@ -1,6 +1,6 @@
 // 检查类型
 export const EXAM_TYPES = [
-  { value: "ultrasound", label: "B超", emoji: "🔊" },
+  { value: "ultrasound", label: "超声", emoji: "🔊" },
   { value: "ct", label: "CT", emoji: "🔬" },
   { value: "mri", label: "MRI", emoji: "🧲" },
   { value: "colonoscopy", label: "肠镜", emoji: "🔭" },

--- a/src/pages/exam/add/index.tsx
+++ b/src/pages/exam/add/index.tsx
@@ -280,7 +280,7 @@ export default function ExamAdd() {
                 className={`exam-type-item ${examType === opt.value ? "active" : ""}`}
                 onClick={() => setExamType(opt.value)}
               >
-                {opt.emoji} {opt.label}
+                {opt.label}
               </View>
             ))}
           </View>

--- a/src/pages/history/index.css
+++ b/src/pages/history/index.css
@@ -29,11 +29,11 @@
 }
 
 .type-icon {
-  font-size: 24px;
+  font-size: 28px;
 }
 
 .type-label {
-  font-size: 22px;
+  font-size: 26px;
   color: #666;
 }
 

--- a/src/pages/history/index.css
+++ b/src/pages/history/index.css
@@ -29,11 +29,11 @@
 }
 
 .type-icon {
-  font-size: 28px;
+  font-size: 24px;
 }
 
 .type-label {
-  font-size: 26px;
+  font-size: 22px;
   color: #666;
 }
 

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -34,6 +34,8 @@ export default function History() {
     "medication",
     "meal",
     "stool",
+    "labtest",
+    "exam",
   ]);
   const [loading, setLoading] = useState(true);
   const [records, setRecords] = useState<AnyRecord[]>([]);

--- a/src/pages/labtest/add/index.tsx
+++ b/src/pages/labtest/add/index.tsx
@@ -23,7 +23,7 @@ export default function LabTestAdd() {
   const isEdit = !!editId;
 
   const [date, setDate] = useState(formatDate());
-  const [time, setTime] = useState(formatTime());
+  const [time, setTime] = useState("10:00");
   const [specimen, setSpecimen] = useState<SpecimenType>("血液");
   // 本地待上传的图片路径
   const [localImages, setLocalImages] = useState<string[]>([]);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -13,9 +13,14 @@ export function formatTime(date: Date = new Date()): string {
   return `${hours}:${minutes}`;
 }
 
-// 格式化显示日期 (4月10日)
+// 格式化显示日期 (4月10日，非今年显示年份：2025年4月10日)
 export function formatDisplayDate(dateStr: string): string {
   const date = new Date(dateStr);
+  const currentYear = new Date().getFullYear();
+  const year = date.getFullYear();
+  if (year !== currentYear) {
+    return `${year}年${date.getMonth() + 1}月${date.getDate()}日`;
+  }
   return `${date.getMonth() + 1}月${date.getDate()}日`;
 }
 


### PR DESCRIPTION
## Summary

- Show category names (e.g., 血常规、肝功能) in labtest list view instead of indicator count
- Allow up to 3 lines for record descriptions (all record types)
- Show up to 9 categories for labtest records
- History page: select all record types by default
- History page: show year in date when not current year
- Exam: remove emoji from record display and type options
- Exam: rename B超 to 超声
- Labtest/Exam: default time to 10:00 for new records

Closes #113

## Test plan

- [ ] Verify labtest with categories shows them (e.g., `血常规、肝功能`)
- [ ] Verify labtest with >9 categories shows first 9 + count
- [ ] Verify labtest with no indicators shows image count
- [ ] Verify record descriptions can wrap to 3 lines
- [ ] Verify history page selects all 6 types by default
- [ ] Verify history page shows year for non-current-year dates
- [ ] Verify exam records don't show emoji
- [ ] Verify new labtest/exam records default to 10:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)