### PR TITLE
fix(exam): limit to 1 image for exam reports

### DIFF
--- a/src/pages/exam/add/index.tsx
+++ b/src/pages/exam/add/index.tsx
@@ -69,7 +69,7 @@ export default function ExamAdd() {
 
   const handleChooseImage = async () => {
     const totalImages = localImages.length + uploadedImages.length;
-    if (totalImages >= 6) return;
+    if (totalImages >= 1) return;
 
     try {
       const tempPaths = await chooseImage(1);
@@ -317,7 +317,7 @@ export default function ExamAdd() {
               </View>
             </View>
           ))}
-          {totalImages < 6 && (
+          {totalImages < 1 && (
             <View className="image-add" onClick={handleChooseImage}>
               <Text className="image-add-icon">+</Text>
               <Text className="image-add-text">添加图片</Text>


### PR DESCRIPTION
## Summary

- Limit exam report to single image upload instead of 6
- Simplifies recognition flow since AI only processes one image anyway

Closes #122

## Test plan

- [ ] Verify exam add page only shows "add image" button when no image exists
- [ ] Verify cannot add more than 1 image

🤖 Generated with [Claude Code](https://claude.com/claude-code)