### PR TITLE
feat(calendar): add swipe gesture and year navigation (#112)

### DIFF
--- a/src/components/CalendarPopup/index.css
+++ b/src/components/CalendarPopup/index.css
@@ -88,3 +88,36 @@
   background-color: #07c160;
   color: #fff;
 }
+
+/* Swipe animations */
+@keyframes slide-in-left {
+  from {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-right {
+  from {
+    transform: translateX(-30px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.calendar-days.slide-left {
+  animation: slide-in-left 0.2s ease-out;
+}
+
+.calendar-days.slide-right {
+  animation: slide-in-right 0.2s ease-out;
+}

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -139,7 +139,9 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
   const handleTouchStart = (e: {
     touches: { clientX: number }[];
     target: { dataset?: { index?: string } };
+    stopPropagation: () => void;
   }) => {
+    e.stopPropagation();
     const touch = e.touches[0];
     const targetIndex = e.target.dataset?.index;
     touchRef.current = {
@@ -148,7 +150,15 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
     };
   };
 
-  const handleTouchEnd = (e: { changedTouches: { clientX: number }[] }) => {
+  const handleTouchMove = (e: { stopPropagation: () => void }) => {
+    e.stopPropagation();
+  };
+
+  const handleTouchEnd = (e: {
+    changedTouches: { clientX: number }[];
+    stopPropagation: () => void;
+  }) => {
+    e.stopPropagation();
     const touch = e.changedTouches[0];
     const deltaX = touch.clientX - touchRef.current.startX;
     const absDelta = Math.abs(deltaX);
@@ -206,7 +216,13 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
         </View>
 
         {/* 日期网格 */}
-        <View className="calendar-days" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+        <View
+          className="calendar-days"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          catchMove
+        >
           {days.map((dayInfo, index) => (
             <View
               key={index}

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -87,6 +87,7 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
   const today = formatDate();
   const [viewYear, setViewYear] = useState(() => parseInt(value.slice(0, 4)));
   const [viewMonth, setViewMonth] = useState(() => parseInt(value.slice(5, 7)) - 1);
+  const [slideDirection, setSlideDirection] = useState<"left" | "right" | null>(null);
 
   const SWIPE_THRESHOLD = 50;
   const TAP_THRESHOLD = 10;
@@ -180,10 +181,14 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
       // Swipe detected
       if (deltaX > 0) {
         // Swipe right -> previous month (like iOS calendar)
+        setSlideDirection("right");
         handlePrevMonth();
+        setTimeout(() => setSlideDirection(null), 200);
       } else {
         // Swipe left -> next month (like iOS calendar)
+        setSlideDirection("left");
         handleNextMonth();
+        setTimeout(() => setSlideDirection(null), 200);
       }
     } else if (absDelta < TAP_THRESHOLD && touchRef.current.targetIndex !== null) {
       // Tap detected
@@ -240,7 +245,7 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
 
         {/* 日期网格 */}
         <View
-          className="calendar-days"
+          className={`calendar-days ${slideDirection ? `slide-${slideDirection}` : ""}`}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -173,6 +173,7 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
           {days.map((dayInfo, index) => (
             <View
               key={index}
+              data-index={index}
               className={`calendar-day ${!dayInfo.isCurrentMonth ? "other-month" : ""} ${dayInfo.dateStr === today ? "today" : ""} ${dayInfo.dateStr === value ? "selected" : ""} ${dayInfo.dateStr > today ? "future" : ""}`}
               onClick={() => handleDayClick(dayInfo)}
             >

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -102,6 +102,19 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
 
   const days = generateCalendarDays(viewYear, viewMonth);
 
+  const handlePrevYear = () => {
+    setViewYear(viewYear - 1);
+  };
+
+  const handleNextYear = () => {
+    const todayYear = parseInt(today.slice(0, 4));
+    // 不能超过今天所在年份
+    if (viewYear >= todayYear) {
+      return;
+    }
+    setViewYear(viewYear + 1);
+  };
+
   const handlePrevMonth = () => {
     if (viewMonth === 0) {
       setViewYear(viewYear - 1);
@@ -186,12 +199,16 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
   const todayYear = parseInt(today.slice(0, 4));
   const todayMonth = parseInt(today.slice(5, 7)) - 1;
   const isCurrentMonth = viewYear === todayYear && viewMonth === todayMonth;
+  const isCurrentYear = viewYear === todayYear;
 
   return (
     <View className="calendar-popup-mask" onClick={onClose}>
       <View className="calendar-popup" onClick={(e) => e.stopPropagation()}>
         {/* 月份标题 */}
         <View className="calendar-header">
+          <Text className="calendar-nav" onClick={handlePrevYear}>
+            ◀◀
+          </Text>
           <Text className="calendar-nav" onClick={handlePrevMonth}>
             ◀
           </Text>
@@ -203,6 +220,12 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
             onClick={handleNextMonth}
           >
             ▶
+          </Text>
+          <Text
+            className={`calendar-nav ${isCurrentYear ? "disabled" : ""}`}
+            onClick={handleNextYear}
+          >
+            ▶▶
           </Text>
         </View>
 

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -206,13 +206,12 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
         </View>
 
         {/* 日期网格 */}
-        <View className="calendar-days">
+        <View className="calendar-days" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
           {days.map((dayInfo, index) => (
             <View
               key={index}
               data-index={index}
               className={`calendar-day ${!dayInfo.isCurrentMonth ? "other-month" : ""} ${dayInfo.dateStr === today ? "today" : ""} ${dayInfo.dateStr === value ? "selected" : ""} ${dayInfo.dateStr > today ? "future" : ""}`}
-              onClick={() => handleDayClick(dayInfo)}
             >
               <Text className="day-text">{dayInfo.day}</Text>
             </View>

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -136,6 +136,43 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
     onClose();
   };
 
+  const handleTouchStart = (e: {
+    touches: { clientX: number }[];
+    target: { dataset?: { index?: string } };
+  }) => {
+    const touch = e.touches[0];
+    const targetIndex = e.target.dataset?.index;
+    touchRef.current = {
+      startX: touch.clientX,
+      targetIndex: targetIndex !== undefined ? parseInt(targetIndex, 10) : null,
+    };
+  };
+
+  const handleTouchEnd = (e: { changedTouches: { clientX: number }[] }) => {
+    const touch = e.changedTouches[0];
+    const deltaX = touch.clientX - touchRef.current.startX;
+    const absDelta = Math.abs(deltaX);
+
+    if (absDelta >= SWIPE_THRESHOLD) {
+      // Swipe detected
+      if (deltaX > 0) {
+        // Swipe right -> next month
+        handleNextMonth();
+      } else {
+        // Swipe left -> previous month
+        handlePrevMonth();
+      }
+    } else if (absDelta < TAP_THRESHOLD && touchRef.current.targetIndex !== null) {
+      // Tap detected
+      const dayInfo = days[touchRef.current.targetIndex];
+      if (dayInfo) {
+        handleDayClick(dayInfo);
+      }
+    }
+    // Reset touch state
+    touchRef.current = { startX: 0, targetIndex: null };
+  };
+
   const todayYear = parseInt(today.slice(0, 4));
   const todayMonth = parseInt(today.slice(5, 7)) - 1;
   const isCurrentMonth = viewYear === todayYear && viewMonth === todayMonth;

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -1,7 +1,12 @@
 import { View, Text } from "@tarojs/components";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { formatDate } from "../../utils/date";
 import "./index.css";
+
+interface TouchState {
+  startX: number;
+  targetIndex: number | null;
+}
 
 interface CalendarPopupProps {
   visible: boolean;
@@ -82,6 +87,10 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
   const today = formatDate();
   const [viewYear, setViewYear] = useState(() => parseInt(value.slice(0, 4)));
   const [viewMonth, setViewMonth] = useState(() => parseInt(value.slice(5, 7)) - 1);
+
+  const SWIPE_THRESHOLD = 50;
+  const TAP_THRESHOLD = 10;
+  const touchRef = useRef<TouchState>({ startX: 0, targetIndex: null });
 
   // 当 value 改变时，更新视图月份
   useEffect(() => {

--- a/src/components/CalendarPopup/index.tsx
+++ b/src/components/CalendarPopup/index.tsx
@@ -156,11 +156,11 @@ export default function CalendarPopup({ visible, value, onChange, onClose }: Cal
     if (absDelta >= SWIPE_THRESHOLD) {
       // Swipe detected
       if (deltaX > 0) {
-        // Swipe right -> next month
-        handleNextMonth();
-      } else {
-        // Swipe left -> previous month
+        // Swipe right -> previous month (like iOS calendar)
         handlePrevMonth();
+      } else {
+        // Swipe left -> next month (like iOS calendar)
+        handleNextMonth();
       }
     } else if (absDelta < TAP_THRESHOLD && touchRef.current.targetIndex !== null) {
       // Tap detected


### PR DESCRIPTION
## Summary
- Add swipe gesture to CalendarPopup for switching months (swipe left = next, swipe right = previous, matching iOS calendar)
- Add year navigation arrows (◀◀ / ▶▶) in addition to month arrows
- Add subtle slide animation (200ms) when swiping between months
- Prevent touch event bubbling to avoid background page jitter

Closes #112

## Test plan
- [ ] Open calendar popup from any date picker page
- [ ] Swipe left → next month (unless at current month)
- [ ] Swipe right → previous month
- [ ] Tap on a day → selects date and closes popup
- [ ] Tap ◀◀ / ▶▶ → navigates by year
- [ ] Cannot navigate past current month/year
- [ ] Animation plays smoothly on swipe

🤖 Generated with [Claude Code](https://claude.ai/code)