### PR TITLE
feat(history): persist category filter selection

### DIFF
--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -14,10 +14,10 @@ import type {
   LabTestRecord,
   LabTestIndicator,
   ExamRecord,
+  RecordType,
 } from "../../types";
+import { RECORD_TYPE_OPTIONS } from "../../types";
 import "./index.css";
-
-type RecordType = "symptom" | "medication" | "meal" | "stool" | "labtest" | "exam";
 
 export type AnyRecord =
   | (SymptomRecord & { _type: "symptom" })
@@ -32,23 +32,9 @@ interface RecordItemProps {
   showTypeIcon?: boolean;
 }
 
-const TYPE_ICONS: Record<RecordType, string> = {
-  symptom: "🌱",
-  medication: "💊",
-  meal: "🍱",
-  stool: "💩",
-  labtest: "🧪",
-  exam: "🩺",
-};
-
-const EDIT_PATHS: Record<RecordType, string> = {
-  symptom: "/pages/symptom/add/index",
-  medication: "/pages/medication/add/index",
-  meal: "/pages/meal/add/index",
-  stool: "/pages/stool/add/index",
-  labtest: "/pages/labtest/add/index",
-  exam: "/pages/exam/add/index",
-};
+const RECORD_TYPE_MAP = Object.fromEntries(
+  RECORD_TYPE_OPTIONS.map((opt) => [opt.value, opt]),
+) as Record<RecordType, (typeof RECORD_TYPE_OPTIONS)[number]>;
 
 const UNKNOWN = "❓";
 
@@ -83,8 +69,10 @@ const getLabTestCategories = (indicators: LabTestIndicator[]): string => {
 };
 
 export default function RecordItem({ record, showTypeIcon = false }: RecordItemProps) {
+  const typeInfo = RECORD_TYPE_MAP[record._type];
+
   const handleClick = () => {
-    const path = `${EDIT_PATHS[record._type]}?id=${record._id}`;
+    const path = `${typeInfo.addPath}?id=${record._id}`;
     Taro.navigateTo({ url: path });
   };
 
@@ -149,7 +137,7 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
 
   return (
     <View className="record-item" onClick={handleClick}>
-      {showTypeIcon && <Text className="record-type-icon">{TYPE_ICONS[record._type]}</Text>}
+      {showTypeIcon && <Text className="record-type-icon">{typeInfo.icon}</Text>}
       <Text className="record-time">{record.time || "--:--"}</Text>
       {renderContent()}
     </View>

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -9,29 +9,13 @@ import { labTestService } from "../../services/labtest";
 import { examService } from "../../services/exam";
 import { formatDisplayDate, getWeekday } from "../../utils/date";
 import RecordItem, { AnyRecord } from "../../components/RecordItem";
+import { RecordType, RECORD_TYPES, RECORD_TYPE_OPTIONS } from "../../types";
 import "./index.css";
-
-type RecordType = "symptom" | "medication" | "meal" | "stool" | "labtest" | "exam";
-
-interface TypeOption {
-  value: RecordType;
-  label: string;
-  icon: string;
-}
-
-const TYPE_OPTIONS: TypeOption[] = [
-  { value: "symptom", label: "体感", icon: "🌱" },
-  { value: "medication", label: "用药", icon: "💊" },
-  { value: "meal", label: "饮食", icon: "🍱" },
-  { value: "stool", label: "排便", icon: "💩" },
-  { value: "labtest", label: "化验", icon: "🧪" },
-  { value: "exam", label: "检查", icon: "🩺" },
-];
 
 export default function History() {
   const [selectedTypes, setSelectedTypes] = useState<RecordType[]>(() => {
     const saved = Taro.getStorageSync("history_selected_types");
-    return saved || ["symptom", "medication", "meal", "stool", "labtest", "exam"];
+    return saved || [...RECORD_TYPES];
   });
   const [loading, setLoading] = useState(true);
   const [records, setRecords] = useState<AnyRecord[]>([]);
@@ -144,7 +128,7 @@ export default function History() {
     <View className="history-page">
       {/* 类型筛选 */}
       <View className="type-filter">
-        {TYPE_OPTIONS.map((option) => (
+        {RECORD_TYPE_OPTIONS.map((option) => (
           <View
             key={option.value}
             className={`type-option ${selectedTypes.includes(option.value) ? "active" : ""}`}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -29,14 +29,10 @@ const TYPE_OPTIONS: TypeOption[] = [
 ];
 
 export default function History() {
-  const [selectedTypes, setSelectedTypes] = useState<RecordType[]>([
-    "symptom",
-    "medication",
-    "meal",
-    "stool",
-    "labtest",
-    "exam",
-  ]);
+  const [selectedTypes, setSelectedTypes] = useState<RecordType[]>(() => {
+    const saved = Taro.getStorageSync("history_selected_types");
+    return saved || ["symptom", "medication", "meal", "stool", "labtest", "exam"];
+  });
   const [loading, setLoading] = useState(true);
   const [records, setRecords] = useState<AnyRecord[]>([]);
 
@@ -129,6 +125,7 @@ export default function History() {
       newTypes = [...selectedTypes, type];
     }
     setSelectedTypes(newTypes);
+    Taro.setStorageSync("history_selected_types", newTypes);
     loadData(newTypes);
   };
 

--- a/src/pages/records/index.tsx
+++ b/src/pages/records/index.tsx
@@ -10,10 +10,12 @@ import { examService } from "../../services/exam";
 import { formatDate, getPrevDate, getNextDate, getWeekday } from "../../utils/date";
 import RecordItem, { AnyRecord } from "../../components/RecordItem";
 import CalendarPopup from "../../components/CalendarPopup";
+import type { RecordType } from "../../types";
+import { RECORD_TYPE_OPTIONS } from "../../types";
 import "./index.css";
 
 interface RecordGroup {
-  type: "symptom" | "medication" | "meal" | "stool" | "labtest" | "exam";
+  type: RecordType;
   icon: string;
   title: string;
   addPath: string;
@@ -38,50 +40,24 @@ export default function Records() {
         examService.getByDate(date),
       ]);
 
-      setRecordGroups([
-        {
-          type: "symptom",
-          icon: "🌱",
-          title: "体感",
-          addPath: "/pages/symptom/add/index",
-          records: symptoms.map((r) => ({ ...r, _type: "symptom" as const })),
-        },
-        {
-          type: "medication",
-          icon: "💊",
-          title: "用药",
-          addPath: "/pages/medication/add/index",
-          records: medications.map((r) => ({ ...r, _type: "medication" as const })),
-        },
-        {
-          type: "meal",
-          icon: "🍱",
-          title: "饮食",
-          addPath: "/pages/meal/add/index",
-          records: meals.map((r) => ({ ...r, _type: "meal" as const })),
-        },
-        {
-          type: "stool",
-          icon: "💩",
-          title: "排便",
-          addPath: "/pages/stool/add/index",
-          records: stools.map((r) => ({ ...r, _type: "stool" as const })),
-        },
-        {
-          type: "labtest",
-          icon: "🧪",
-          title: "化验",
-          addPath: "/pages/labtest/add/index",
-          records: labTests.map((r) => ({ ...r, _type: "labtest" as const })),
-        },
-        {
-          type: "exam",
-          icon: "🩺",
-          title: "检查",
-          addPath: "/pages/exam/add/index",
-          records: exams.map((r) => ({ ...r, _type: "exam" as const })),
-        },
-      ]);
+      const recordsMap: Record<RecordType, AnyRecord[]> = {
+        symptom: symptoms.map((r) => ({ ...r, _type: "symptom" as const })),
+        medication: medications.map((r) => ({ ...r, _type: "medication" as const })),
+        meal: meals.map((r) => ({ ...r, _type: "meal" as const })),
+        stool: stools.map((r) => ({ ...r, _type: "stool" as const })),
+        labtest: labTests.map((r) => ({ ...r, _type: "labtest" as const })),
+        exam: exams.map((r) => ({ ...r, _type: "exam" as const })),
+      };
+
+      setRecordGroups(
+        RECORD_TYPE_OPTIONS.map((opt) => ({
+          type: opt.value,
+          icon: opt.icon,
+          title: opt.label,
+          addPath: opt.addPath,
+          records: recordsMap[opt.value],
+        })),
+      );
     } catch (error) {
       console.error("加载数据失败:", error);
       Taro.showToast({ title: "加载失败", icon: "none" });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,23 @@
+// 记录类型
+export const RECORD_TYPES = ["symptom", "medication", "meal", "stool", "labtest", "exam"] as const;
+export type RecordType = (typeof RECORD_TYPES)[number];
+
+export interface RecordTypeOption {
+  value: RecordType;
+  label: string;
+  icon: string;
+  addPath: string;
+}
+
+export const RECORD_TYPE_OPTIONS: RecordTypeOption[] = [
+  { value: "symptom", label: "体感", icon: "🌱", addPath: "/pages/symptom/add/index" },
+  { value: "medication", label: "用药", icon: "💊", addPath: "/pages/medication/add/index" },
+  { value: "meal", label: "饮食", icon: "🍱", addPath: "/pages/meal/add/index" },
+  { value: "stool", label: "排便", icon: "💩", addPath: "/pages/stool/add/index" },
+  { value: "labtest", label: "化验", icon: "🧪", addPath: "/pages/labtest/add/index" },
+  { value: "exam", label: "检查", icon: "🩺", addPath: "/pages/exam/add/index" },
+];
+
 // 用户信息
 export interface User {
   _id: string; // openid


### PR DESCRIPTION
## Summary
- Save selected category filters to local storage when user toggles them
- Restore saved filter selection when history page opens
- Default to all 6 categories when no saved state exists

Closes #131

## Test plan
- [ ] Open history page, toggle some filters off
- [ ] Navigate away and return — filters should be restored
- [ ] Clear storage and reopen — should show all 6 categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)