### PR TITLE
fix: suppress cloud property type error in app.config.ts

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -44,5 +44,6 @@ export default defineAppConfig({
       },
     ],
   },
+  // @ts-expect-error WeChat cloud development - not typed in Taro's AppConfig
   cloud: true,
 });


### PR DESCRIPTION
## Summary
- Added `@ts-expect-error` comment to suppress type error for `cloud` property
- This is a valid WeChat miniprogram cloud development config not typed in Taro's AppConfig

Closes #133

## Test plan
- [x] TypeScript compilation passes for app.config.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)