### PR TITLE
refactor(meal): replace emoji quantity indicators with SVG icons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Design Documentation
 
-Do not create local design/spec files. All design documents should be written directly in the GitHub issue.
+Do not create local design/spec files (e.g., `docs/superpowers/specs/`). All design documents should be written directly in the GitHub issue using `gh issue edit`.
 
 ## Package Manager
 

--- a/src/components/AmountIcon/index.tsx
+++ b/src/components/AmountIcon/index.tsx
@@ -1,0 +1,38 @@
+import { Image } from "@tarojs/components";
+
+function generateAmountSvg(level: 1 | 2 | 3): string {
+  const filled = "#07C160";
+  const empty = "#E5E5E5";
+  const colors = [
+    level >= 1 ? filled : empty,
+    level >= 2 ? filled : empty,
+    level >= 3 ? filled : empty,
+  ];
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 12">
+    <rect x="0" y="0" width="10" height="12" rx="2" fill="${colors[0]}"/>
+    <rect x="13" y="0" width="10" height="12" rx="2" fill="${colors[1]}"/>
+    <rect x="26" y="0" width="10" height="12" rx="2" fill="${colors[2]}"/>
+  </svg>`;
+}
+
+function svgToDataUri(svg: string): string {
+  const encoded = encodeURIComponent(svg.replace(/\s+/g, " ").trim());
+  return `data:image/svg+xml,${encoded}`;
+}
+
+interface AmountIconProps {
+  level: 1 | 2 | 3;
+  size?: number;
+}
+
+export default function AmountIcon({ level, size = 36 }: AmountIconProps) {
+  const height = size / 3;
+  return (
+    <Image
+      src={svgToDataUri(generateAmountSvg(level))}
+      style={{ width: size, height }}
+      mode="aspectFit"
+    />
+  );
+}

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -2,7 +2,7 @@ import { View, Text } from "@tarojs/components";
 import Taro from "@tarojs/taro";
 import { EXAM_TYPES } from "../../constants/exam";
 import { SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../constants/symptom";
-import { AMOUNT_OPTIONS } from "../../constants/meal";
+import AmountIcon from "../AmountIcon";
 import { STOOL_AMOUNTS } from "../../constants/stool";
 import { normalizeIndicators } from "../../services/labtest-standards";
 import BristolIcon from "../BristolIcon";
@@ -45,10 +45,6 @@ const getFeelingEmoji = (value: number): string => {
 const getSeverityInfo = (severity?: 1 | 2 | 3) => {
   if (!severity) return null;
   return SEVERITY_OPTIONS.find((s) => s.value === severity) ?? null;
-};
-
-const getAmountEmoji = (amount: number): string => {
-  return AMOUNT_OPTIONS.find((a) => a.value === amount)?.emoji ?? UNKNOWN;
 };
 
 const getStoolAmountLabel = (amount: number): string => {
@@ -99,7 +95,9 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
       case "meal":
         return (
           <>
-            <Text className="record-feeling">{getAmountEmoji(record.amount)}</Text>
+            <View className="record-feeling">
+              <AmountIcon level={record.amount as 1 | 2 | 3} size={24} />
+            </View>
             <Text className="record-desc">{record.foods.join("、")}</Text>
           </>
         );

--- a/src/constants/meal.ts
+++ b/src/constants/meal.ts
@@ -99,7 +99,7 @@ export const FOOD_CATEGORIES = [
 
 // 进食量选项
 export const AMOUNT_OPTIONS = [
-  { value: 1, label: "少量", emoji: "▰▱▱" },
-  { value: 2, label: "适中", emoji: "▰▰▱" },
-  { value: 3, label: "大量", emoji: "▰▰▰" },
+  { value: 1, label: "少量" },
+  { value: 2, label: "适中" },
+  { value: 3, label: "大量" },
 ] as const;

--- a/src/pages/meal/add/index.css
+++ b/src/pages/meal/add/index.css
@@ -149,7 +149,6 @@
 }
 
 .amount-emoji {
-  font-size: 40px;
   margin-bottom: 8px;
 }
 

--- a/src/pages/meal/add/index.tsx
+++ b/src/pages/meal/add/index.tsx
@@ -7,6 +7,7 @@ import { formatDate, formatTime } from "../../../utils/date";
 import { validateFood } from "../../../utils/validation";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
+import AmountIcon from "../../../components/AmountIcon";
 import "./index.css";
 
 const CUSTOM_FOODS_KEY = "custom_foods";
@@ -323,7 +324,7 @@ export default function MealAdd() {
               className={`amount-item ${amount === option.value ? "active" : ""}`}
               onClick={() => setAmount(option.value as typeof amount)}
             >
-              <Text className="amount-emoji">{option.emoji}</Text>
+              <AmountIcon level={option.value} />
               <Text className="amount-label">{option.label}</Text>
             </View>
           ))}


### PR DESCRIPTION
## Summary
- Add `AmountIcon` component with three-segment progress bar SVG
- Replace Unicode block characters (`▰▱▱`) with cleaner SVG rendering
- Use WeChat green (`#07C160`) for filled segments

## Changes
- New: `src/components/AmountIcon/index.tsx`
- Modified: `src/constants/meal.ts` (removed emoji field)
- Modified: `src/pages/meal/add/index.tsx` (use AmountIcon)
- Modified: `src/components/RecordItem/index.tsx` (use AmountIcon)

Closes #142

## Test plan
- [ ] Verify quantity selector displays correctly on meal add page
- [ ] Verify quantity icon displays correctly in history list

🤖 Generated with [Claude Code](https://claude.com/claude-code)