### PR TITLE
feat(error): show detailed error info in modal

### DIFF
--- a/src/components/ProfilePopup/index.tsx
+++ b/src/components/ProfilePopup/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { View, Text, Image, Input, Button } from "@tarojs/components";
 import Taro from "@tarojs/taro";
 import { updateUserSettings, uploadAvatar } from "../../services/user";
+import { showError } from "../../utils/error";
 import { validateNickname } from "../../utils/validation";
 import "./index.css";
 
@@ -93,8 +94,7 @@ export default function ProfilePopup({
 
       Taro.showToast({ title: "保存成功", icon: "success" });
     } catch (error) {
-      console.error("保存失败:", error);
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setSaving(false);
     }

--- a/src/pages/common/mosaic/index.tsx
+++ b/src/pages/common/mosaic/index.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Canvas } from "@tarojs/components";
 import Taro, { useRouter } from "@tarojs/taro";
 import { useState, useRef, useEffect } from "react";
+import { showError } from "../../../utils/error";
 import "./index.css";
 
 interface Point {
@@ -253,8 +254,7 @@ export default function MosaicEditor() {
 
       Taro.navigateBack();
     } catch (error) {
-      console.error("保存失败:", error);
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setProcessing(false);
     }

--- a/src/pages/exam/add/index.tsx
+++ b/src/pages/exam/add/index.tsx
@@ -5,6 +5,7 @@ import { examService } from "../../../services/exam";
 import { recognizeExamReport } from "../../../services/ai";
 import { chooseImage, uploadImage, deleteCloudFile } from "../../../utils/upload";
 import { formatDate } from "../../../utils/date";
+import { showError } from "../../../utils/error";
 import { EXAM_TYPES } from "../../../constants/exam";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
@@ -61,8 +62,7 @@ export default function ExamAdd() {
         setUploadedImages(record.imageFileIds || []);
       }
     } catch (error) {
-      console.error("加载记录失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
+      showError("加载失败", error);
     } finally {
       setLoading(false);
     }
@@ -110,8 +110,7 @@ export default function ExamAdd() {
         await deleteCloudFile(fileId);
         setUploadedImages(uploadedImages.filter((_, i) => i !== index));
       } catch (error) {
-        console.error("删除云存储图片失败:", error);
-        Taro.showToast({ title: "删除失败", icon: "none" });
+        showError("删除失败", error);
       }
     }
   };
@@ -156,9 +155,8 @@ export default function ExamAdd() {
       Taro.hideLoading();
       Taro.showToast({ title: "识别完成", icon: "success" });
     } catch (error) {
-      console.error("识别失败:", error);
       Taro.hideLoading();
-      Taro.showToast({ title: "识别失败", icon: "none" });
+      showError("识别失败", error);
     } finally {
       setRecognizing(false);
     }
@@ -182,8 +180,8 @@ export default function ExamAdd() {
         setTimeout(() => {
           Taro.navigateBack();
         }, 1500);
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
+      } catch (error) {
+        showError("删除失败", error);
       }
     }
   };
@@ -231,9 +229,8 @@ export default function ExamAdd() {
         Taro.navigateBack();
       }, 1500);
     } catch (error) {
-      console.error("保存失败:", error);
       Taro.hideLoading();
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/labtest/add/index.tsx
+++ b/src/pages/labtest/add/index.tsx
@@ -6,6 +6,7 @@ import { recognizeLabTestImage } from "../../../services/ai";
 import { normalizeIndicators, type SpecimenType } from "../../../services/labtest-standards";
 import { chooseImage, uploadImage, deleteCloudFile } from "../../../utils/upload";
 import { formatDate, formatTime } from "../../../utils/date";
+import { showError } from "../../../utils/error";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
 import type { LabTestIndicator } from "../../../types";
@@ -69,8 +70,7 @@ export default function LabTestAdd() {
         setIndicators(normalizeIndicators(record.indicators || [], recordSpecimen));
       }
     } catch (error) {
-      console.error("加载记录失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
+      showError("加载失败", error);
     } finally {
       setLoading(false);
     }
@@ -120,8 +120,7 @@ export default function LabTestAdd() {
         await deleteCloudFile(fileId);
         setUploadedImages(uploadedImages.filter((_, i) => i !== index));
       } catch (error) {
-        console.error("删除云存储图片失败:", error);
-        Taro.showToast({ title: "删除失败", icon: "none" });
+        showError("删除失败", error);
       }
     }
   };
@@ -162,9 +161,8 @@ export default function LabTestAdd() {
         Taro.showToast({ title: `识别到 ${newIndicators.length} 项指标`, icon: "success" });
       }
     } catch (error) {
-      console.error("识别失败:", error);
       Taro.hideLoading();
-      Taro.showToast({ title: "识别失败", icon: "none" });
+      showError("识别失败", error);
     } finally {
       setRecognizing(false);
     }
@@ -189,8 +187,8 @@ export default function LabTestAdd() {
         setTimeout(() => {
           Taro.navigateBack();
         }, 1500);
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
+      } catch (error) {
+        showError("删除失败", error);
       }
     }
   };
@@ -237,9 +235,8 @@ export default function LabTestAdd() {
         Taro.navigateBack();
       }, 1500);
     } catch (error) {
-      console.error("保存失败:", error);
       Taro.hideLoading();
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/meal/add/index.tsx
+++ b/src/pages/meal/add/index.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { mealService } from "../../../services/meal";
 import { FOOD_CATEGORIES, AMOUNT_OPTIONS } from "../../../constants/meal";
 import { formatDate, formatTime } from "../../../utils/date";
+import { showError } from "../../../utils/error";
 import { validateFood } from "../../../utils/validation";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
@@ -77,8 +78,7 @@ export default function MealAdd() {
         setNote(record.note || "");
       }
     } catch (error) {
-      console.error("加载记录失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
+      showError("加载失败", error);
     } finally {
       setLoading(false);
     }
@@ -156,8 +156,8 @@ export default function MealAdd() {
         setTimeout(() => {
           Taro.navigateBack();
         }, 1500);
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
+      } catch (error) {
+        showError("删除失败", error);
       }
     }
   };
@@ -192,8 +192,7 @@ export default function MealAdd() {
         Taro.navigateBack();
       }, 1500);
     } catch (error) {
-      console.error("保存失败:", error);
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/medication/add/index.tsx
+++ b/src/pages/medication/add/index.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { medicationService } from "../../../services/medication";
 import { MEDICATION_CATEGORIES } from "../../../constants/medication";
 import { formatDate, formatTime } from "../../../utils/date";
+import { showError } from "../../../utils/error";
 import { validateMedication } from "../../../utils/validation";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
@@ -67,8 +68,7 @@ export default function MedicationAdd() {
         setNote(record.note || "");
       }
     } catch (error) {
-      console.error("加载记录失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
+      showError("加载失败", error);
     } finally {
       setLoading(false);
     }
@@ -144,8 +144,8 @@ export default function MedicationAdd() {
         setTimeout(() => {
           Taro.navigateBack();
         }, 1500);
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
+      } catch (error) {
+        showError("删除失败", error);
       }
     }
   };
@@ -179,8 +179,7 @@ export default function MedicationAdd() {
         Taro.navigateBack();
       }, 1500);
     } catch (error) {
-      console.error("保存失败:", error);
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/stool/add/index.tsx
+++ b/src/pages/stool/add/index.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { stoolService } from "../../../services/stool";
 import { BRISTOL_TYPES, STOOL_AMOUNTS, NOTE_SHORTCUTS } from "../../../constants/stool";
 import { formatDate, formatTime } from "../../../utils/date";
+import { showError } from "../../../utils/error";
 import BristolIcon from "../../../components/BristolIcon";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
@@ -41,8 +42,7 @@ export default function StoolAdd() {
         setNote(record.note || "");
       }
     } catch (error) {
-      console.error("加载记录失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
+      showError("加载失败", error);
     } finally {
       setLoading(false);
     }
@@ -63,8 +63,8 @@ export default function StoolAdd() {
         setTimeout(() => {
           Taro.navigateBack();
         }, 1500);
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
+      } catch (error) {
+        showError("删除失败", error);
       }
     }
   };
@@ -94,8 +94,7 @@ export default function StoolAdd() {
         Taro.navigateBack();
       }, 1500);
     } catch (error) {
-      console.error("保存失败:", error);
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { symptomService } from "../../../services/symptom";
 import { SYMPTOM_SHORTCUTS, SEVERITY_OPTIONS, FEELING_OPTIONS } from "../../../constants/symptom";
 import { formatDate, formatTime } from "../../../utils/date";
+import { showError } from "../../../utils/error";
 import { validateSymptom } from "../../../utils/validation";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
@@ -67,8 +68,7 @@ export default function SymptomAdd() {
         setNote(record.note || "");
       }
     } catch (error) {
-      console.error("加载记录失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
+      showError("加载失败", error);
     } finally {
       setLoading(false);
     }
@@ -136,8 +136,8 @@ export default function SymptomAdd() {
         setTimeout(() => {
           Taro.navigateBack();
         }, 1500);
-      } catch {
-        Taro.showToast({ title: "删除失败", icon: "none" });
+      } catch (error) {
+        showError("删除失败", error);
       }
     }
   };
@@ -168,8 +168,7 @@ export default function SymptomAdd() {
         Taro.navigateBack();
       }, 1500);
     } catch (error) {
-      console.error("保存失败:", error);
-      Taro.showToast({ title: "保存失败", icon: "none" });
+      showError("保存失败", error);
     } finally {
       setSubmitting(false);
     }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,40 @@
+import Taro from "@tarojs/taro";
+
+/**
+ * 从错误对象中提取详细信息
+ */
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "object" && error !== null) {
+    // 微信云开发错误通常有 errMsg 字段
+    const wxError = error as { errMsg?: string; message?: string; errCode?: number };
+    if (wxError.errMsg) {
+      return wxError.errMsg;
+    }
+    if (wxError.message) {
+      return wxError.message;
+    }
+    if (wxError.errCode) {
+      return `错误码: ${wxError.errCode}`;
+    }
+    return JSON.stringify(error);
+  }
+  return String(error);
+}
+
+/**
+ * 显示错误弹窗，包含详细错误信息
+ */
+export function showError(title: string, error: unknown): void {
+  const message = getErrorMessage(error);
+  console.error(`${title}:`, error);
+
+  Taro.showModal({
+    title,
+    content: message,
+    showCancel: false,
+    confirmText: "确定",
+  });
+}


### PR DESCRIPTION
## Summary
- Replace simple toast ("保存失败") with modal dialog showing actual error message
- Helps debug issues for trial users who can't access dev tools
- Added `showError()` utility function in `src/utils/error.ts`

## Test plan
- [ ] Trigger a save failure (e.g., disconnect network) and verify modal shows error details
- [ ] Verify normal success toasts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)