### PR TITLE
feat(history): infinite scroll with cursor-based pagination

### DIFF
--- a/src/pages/history/index.css
+++ b/src/pages/history/index.css
@@ -1,7 +1,13 @@
 .history-page {
-  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
   background-color: #f5f5f5;
-  padding-bottom: 40px;
+}
+
+.records-scroll {
+  flex: 1;
+  height: 0;
 }
 
 /* 类型筛选 */
@@ -91,3 +97,12 @@
   overflow: hidden;
 }
 
+/* 加载更多 */
+.loading-more,
+.no-more {
+  display: flex;
+  justify-content: center;
+  padding: 32px;
+  color: #999;
+  font-size: 26px;
+}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -1,6 +1,6 @@
-import { View, Text } from "@tarojs/components";
-import Taro, { useDidShow, usePullDownRefresh } from "@tarojs/taro";
-import { useState, useCallback } from "react";
+import { View, Text, ScrollView } from "@tarojs/components";
+import Taro, { useDidShow } from "@tarojs/taro";
+import { useState, useCallback, useRef } from "react";
 import { symptomService } from "../../services/symptom";
 import { mealService } from "../../services/meal";
 import { stoolService } from "../../services/stool";
@@ -9,108 +9,100 @@ import { labTestService } from "../../services/labtest";
 import { examService } from "../../services/exam";
 import { formatDisplayDate, getWeekday } from "../../utils/date";
 import RecordItem, { AnyRecord } from "../../components/RecordItem";
-import { RecordType, RECORD_TYPES, RECORD_TYPE_OPTIONS } from "../../types";
+import { RecordType, RECORD_TYPE_OPTIONS } from "../../types";
 import "./index.css";
 
+const PAGE_SIZE = 50;
+
+const services = {
+  symptom: symptomService,
+  medication: medicationService,
+  meal: mealService,
+  stool: stoolService,
+  labtest: labTestService,
+  exam: examService,
+} as const;
+
 export default function History() {
-  const [selectedTypes, setSelectedTypes] = useState<RecordType[]>(() => {
-    const saved = Taro.getStorageSync("history_selected_types");
-    return saved || [...RECORD_TYPES];
+  const [selectedType, setSelectedType] = useState<RecordType>(() => {
+    return Taro.getStorageSync("history_selected_type") || "meal";
   });
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [records, setRecords] = useState<AnyRecord[]>([]);
+  const [hasMore, setHasMore] = useState(true);
 
-  const loadData = useCallback(async (types: RecordType[]) => {
-    setLoading(true);
-    try {
-      const promises: Promise<AnyRecord[]>[] = [];
+  const cursorRef = useRef({ date: "9999-12-31", time: "23:59" });
 
-      if (types.includes("symptom")) {
-        promises.push(
-          symptomService
-            .getRecent(200)
-            .then((data) => data.map((r) => ({ ...r, _type: "symptom" as const }))),
-        );
-      }
-      if (types.includes("medication")) {
-        promises.push(
-          medicationService
-            .getRecent(200)
-            .then((data) => data.map((r) => ({ ...r, _type: "medication" as const }))),
-        );
-      }
-      if (types.includes("meal")) {
-        promises.push(
-          mealService
-            .getRecent(200)
-            .then((data) => data.map((r) => ({ ...r, _type: "meal" as const }))),
-        );
-      }
-      if (types.includes("stool")) {
-        promises.push(
-          stoolService
-            .getRecent(200)
-            .then((data) => data.map((r) => ({ ...r, _type: "stool" as const }))),
-        );
-      }
-      if (types.includes("labtest")) {
-        promises.push(
-          labTestService
-            .getRecent(200)
-            .then((data) => data.map((r) => ({ ...r, _type: "labtest" as const }))),
-        );
-      }
-      if (types.includes("exam")) {
-        promises.push(
-          examService
-            .getRecent(200)
-            .then((data) => data.map((r) => ({ ...r, _type: "exam" as const }))),
-        );
-      }
+  const loadMore = useCallback(async (type: RecordType, isInitial = false) => {
+    const service = services[type];
+    const cursor = cursorRef.current;
 
-      const results = await Promise.all(promises);
-      const allRecords = results.flat();
+    const data = await service.getRecentBefore(cursor.date, cursor.time, PAGE_SIZE);
 
-      // 按日期+时间倒序排列
-      allRecords.sort((a, b) => {
-        const dateCompare = b.date.localeCompare(a.date);
-        if (dateCompare !== 0) return dateCompare;
-        return b.time.localeCompare(a.time);
-      });
-
-      setRecords(allRecords);
-    } catch (error) {
-      console.error("加载数据失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
-    } finally {
-      setLoading(false);
+    if (data.length < PAGE_SIZE) {
+      setHasMore(false);
     }
+
+    if (data.length > 0) {
+      const last = data[data.length - 1];
+      cursorRef.current = { date: last.date, time: last.time };
+    }
+
+    return data.map((r) => ({ ...r, _type: type })) as AnyRecord[];
   }, []);
 
+  const loadInitial = useCallback(
+    async (type: RecordType) => {
+      setLoading(true);
+      setHasMore(true);
+      cursorRef.current = { date: "9999-12-31", time: "23:59" };
+
+      try {
+        const newRecords = await loadMore(type, true);
+        setRecords(newRecords);
+      } catch (error) {
+        console.error("加载数据失败:", error);
+        Taro.showToast({ title: "加载失败", icon: "none" });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loadMore],
+  );
+
+  const handleLoadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) return;
+
+    setLoadingMore(true);
+    try {
+      const newRecords = await loadMore(selectedType);
+      if (newRecords.length > 0) {
+        setRecords((prev) => [...prev, ...newRecords]);
+      }
+    } catch (error) {
+      console.error("加载更多失败:", error);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadMore, selectedType, loadingMore, hasMore]);
+
   useDidShow(() => {
-    // Only load on first visit, not when returning from detail page
     if (records.length === 0) {
-      loadData(selectedTypes);
+      loadInitial(selectedType);
     }
   });
 
-  usePullDownRefresh(async () => {
-    await loadData(selectedTypes);
-    Taro.stopPullDownRefresh();
-  });
+  const handleRefresh = useCallback(async () => {
+    await loadInitial(selectedType);
+  }, [loadInitial, selectedType]);
 
-  const handleTypeToggle = (type: RecordType) => {
-    let newTypes: RecordType[];
-    if (selectedTypes.includes(type)) {
-      // 至少保留一个类型
-      if (selectedTypes.length === 1) return;
-      newTypes = selectedTypes.filter((t) => t !== type);
-    } else {
-      newTypes = [...selectedTypes, type];
-    }
-    setSelectedTypes(newTypes);
-    Taro.setStorageSync("history_selected_types", newTypes);
-    loadData(newTypes);
+  const handleTypeChange = (type: RecordType) => {
+    if (type === selectedType) return;
+    setSelectedType(type);
+    Taro.setStorageSync("history_selected_type", type);
+    setRecords([]);
+    loadInitial(type);
   };
 
   // 按日期分组记录
@@ -126,13 +118,12 @@ export default function History() {
 
   return (
     <View className="history-page">
-      {/* 类型筛选 */}
       <View className="type-filter">
         {RECORD_TYPE_OPTIONS.map((option) => (
           <View
             key={option.value}
-            className={`type-option ${selectedTypes.includes(option.value) ? "active" : ""}`}
-            onClick={() => handleTypeToggle(option.value)}
+            className={`type-option ${selectedType === option.value ? "active" : ""}`}
+            onClick={() => handleTypeChange(option.value)}
           >
             <Text className="type-icon">{option.icon}</Text>
             <Text className="type-label">{option.label}</Text>
@@ -147,22 +138,42 @@ export default function History() {
           <Text className="empty-text">暂无记录</Text>
         </View>
       ) : (
-        <View className="records-list">
-          {groupedRecords.map((group) => (
-            <View key={group.date} className="date-group">
-              <View className="date-header">
-                <Text className="date-text">
-                  {formatDisplayDate(group.date)} {getWeekday(group.date)}
-                </Text>
+        <ScrollView
+          className="records-scroll"
+          scrollY
+          refresherEnabled
+          refresherTriggered={loading}
+          onRefresherRefresh={handleRefresh}
+          onScrollToLower={handleLoadMore}
+          lowerThreshold={100}
+        >
+          <View className="records-list">
+            {groupedRecords.map((group) => (
+              <View key={group.date} className="date-group">
+                <View className="date-header">
+                  <Text className="date-text">
+                    {formatDisplayDate(group.date)} {getWeekday(group.date)}
+                  </Text>
+                </View>
+                <View className="date-records">
+                  {group.records.map((record) => (
+                    <RecordItem key={record._id} record={record} />
+                  ))}
+                </View>
               </View>
-              <View className="date-records">
-                {group.records.map((record) => (
-                  <RecordItem key={record._id} record={record} showTypeIcon />
-                ))}
-              </View>
+            ))}
+          </View>
+          {loadingMore && (
+            <View className="loading-more">
+              <Text>加载中...</Text>
             </View>
-          ))}
-        </View>
+          )}
+          {!hasMore && records.length > 0 && (
+            <View className="no-more">
+              <Text>没有更多了</Text>
+            </View>
+          )}
+        </ScrollView>
       )}
     </View>
   );

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -28,42 +28,42 @@ export default function History() {
       if (types.includes("symptom")) {
         promises.push(
           symptomService
-            .getRecent(50)
+            .getRecent(200)
             .then((data) => data.map((r) => ({ ...r, _type: "symptom" as const }))),
         );
       }
       if (types.includes("medication")) {
         promises.push(
           medicationService
-            .getRecent(50)
+            .getRecent(200)
             .then((data) => data.map((r) => ({ ...r, _type: "medication" as const }))),
         );
       }
       if (types.includes("meal")) {
         promises.push(
           mealService
-            .getRecent(50)
+            .getRecent(200)
             .then((data) => data.map((r) => ({ ...r, _type: "meal" as const }))),
         );
       }
       if (types.includes("stool")) {
         promises.push(
           stoolService
-            .getRecent(50)
+            .getRecent(200)
             .then((data) => data.map((r) => ({ ...r, _type: "stool" as const }))),
         );
       }
       if (types.includes("labtest")) {
         promises.push(
           labTestService
-            .getRecent(50)
+            .getRecent(200)
             .then((data) => data.map((r) => ({ ...r, _type: "labtest" as const }))),
         );
       }
       if (types.includes("exam")) {
         promises.push(
           examService
-            .getRecent(50)
+            .getRecent(200)
             .then((data) => data.map((r) => ({ ...r, _type: "exam" as const }))),
         );
       }

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -18,16 +18,32 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
       const db = getDatabase();
       const userId = await getOpenId();
       const _ = db.command;
-      const res = await db
-        .collection(collection)
-        .where({
-          userId,
-          deletedAt: _.exists(false),
-        })
-        .orderBy("createdAt", "desc")
-        .limit(limit)
-        .get();
-      return res.data as T[];
+
+      // 云数据库单次最多返回20条（小程序端限制），需要分页
+      const PAGE_SIZE = 20;
+      const allData: T[] = [];
+
+      while (allData.length < limit) {
+        const batchLimit = Math.min(PAGE_SIZE, limit - allData.length);
+        const res = await db
+          .collection(collection)
+          .where({
+            userId,
+            deletedAt: _.exists(false),
+          })
+          .orderBy("date", "desc")
+          .orderBy("time", "desc")
+          .skip(allData.length)
+          .limit(batchLimit)
+          .get();
+
+        allData.push(...(res.data as T[]));
+
+        // 如果返回的数据少于请求的，说明没有更多了
+        if (res.data.length < batchLimit) break;
+      }
+
+      return allData;
     },
 
     async delete(id: string): Promise<void> {
@@ -45,16 +61,29 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
       const db = getDatabase();
       const userId = await getOpenId();
       const _ = db.command;
-      const res = await db
-        .collection(collection)
-        .where({
-          userId,
-          date,
-          deletedAt: _.exists(false),
-        })
-        .orderBy("time", "asc")
-        .get();
-      return res.data as T[];
+
+      const PAGE_SIZE = 20;
+      const allData: T[] = [];
+
+      while (true) {
+        const res = await db
+          .collection(collection)
+          .where({
+            userId,
+            date,
+            deletedAt: _.exists(false),
+          })
+          .orderBy("time", "asc")
+          .skip(allData.length)
+          .limit(PAGE_SIZE)
+          .get();
+
+        allData.push(...(res.data as T[]));
+
+        if (res.data.length < PAGE_SIZE) break;
+      }
+
+      return allData;
     },
 
     async getById(id: string): Promise<T | null> {

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -101,5 +101,42 @@ export function createRecordService<T extends BaseRecord>(collection: string) {
       const userId = await getOpenId();
       await db.collection(collection).where({ _id: id, userId }).update({ data });
     },
+
+    async getRecentBefore(beforeDate: string, beforeTime: string, limit = 20): Promise<T[]> {
+      const db = getDatabase();
+      const userId = await getOpenId();
+      const _ = db.command;
+
+      const PAGE_SIZE = 20;
+      const allData: T[] = [];
+
+      while (allData.length < limit) {
+        const batchLimit = Math.min(PAGE_SIZE, limit - allData.length);
+        const res = await db
+          .collection(collection)
+          .where({
+            userId,
+            deletedAt: _.exists(false),
+            date: _.lte(beforeDate),
+          })
+          .orderBy("date", "desc")
+          .orderBy("time", "desc")
+          .skip(allData.length)
+          .limit(batchLimit)
+          .get();
+
+        // 过滤掉同一天但时间 >= beforeTime 的记录
+        const filtered = (res.data as T[]).filter((r) => {
+          if (r.date < beforeDate) return true;
+          return r.time < beforeTime;
+        });
+
+        allData.push(...filtered);
+
+        if (res.data.length < batchLimit) break;
+      }
+
+      return allData.slice(0, limit);
+    },
   };
 }

--- a/src/services/deleteAll.ts
+++ b/src/services/deleteAll.ts
@@ -5,11 +5,16 @@ const COLLECTIONS = ["stool_records", "symptom_records", "meal_records", "medica
 
 async function deleteCollection(collection: string, userId: string): Promise<void> {
   const db = getDatabase();
-  const res = await db.collection(collection).where({ userId }).get();
-  const ids = res.data.map((doc: { _id: string }) => doc._id);
+  const PAGE_SIZE = 20;
 
-  for (const id of ids) {
-    await db.collection(collection).doc(id).remove();
+  // 分页获取所有记录并删除
+  while (true) {
+    const res = await db.collection(collection).where({ userId }).limit(PAGE_SIZE).get();
+    if (res.data.length === 0) break;
+
+    for (const doc of res.data as { _id: string }[]) {
+      await db.collection(collection).doc(doc._id).remove();
+    }
   }
 }
 
@@ -26,12 +31,12 @@ async function deleteCloudFiles(userId: string): Promise<void> {
   try {
     // List and delete user's cloud files (avatar, exports)
     const fileList = await Taro.cloud.getTempFileURL({
-      fileList: [`cloud://cloud1-8gzx205084c1da0f.636c-cloud1-8gzx205084c1da0f-1255262839/${userId}/avatar.jpg`],
+      fileList: [
+        `cloud://cloud1-8gzx205084c1da0f.636c-cloud1-8gzx205084c1da0f-1255262839/${userId}/avatar.jpg`,
+      ],
     });
 
-    const existingFiles = fileList.fileList
-      .filter((f) => f.status === 0)
-      .map((f) => f.fileID);
+    const existingFiles = fileList.fileList.filter((f) => f.status === 0).map((f) => f.fileID);
 
     if (existingFiles.length > 0) {
       await Taro.cloud.deleteFile({ fileList: existingFiles });

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -12,22 +12,43 @@ import type {
 
 async function getAllRecords<T>(collection: string, userId: string): Promise<T[]> {
   const db = getDatabase();
-  const res = await db.collection(collection).where({ userId }).get();
-  return res.data as T[];
+  const PAGE_SIZE = 20;
+  const allData: T[] = [];
+
+  while (true) {
+    const res = await db
+      .collection(collection)
+      .where({ userId })
+      .skip(allData.length)
+      .limit(PAGE_SIZE)
+      .get();
+
+    allData.push(...(res.data as T[]));
+
+    if (res.data.length < PAGE_SIZE) break;
+  }
+
+  return allData;
 }
 
 export async function exportAllData(): Promise<ExportData> {
   const userId = await getOpenId();
 
-  const [stoolRecords, symptomRecords, mealRecords, medicationRecords, labtestRecords, examRecords] =
-    await Promise.all([
-      getAllRecords<StoolRecord>("stool_records", userId),
-      getAllRecords<SymptomRecord>("symptom_records", userId),
-      getAllRecords<MealRecord>("meal_records", userId),
-      getAllRecords<MedicationRecord>("medication_records", userId),
-      getAllRecords<LabTestRecord>("labtest_records", userId),
-      getAllRecords<ExamRecord>("exam_records", userId),
-    ]);
+  const [
+    stoolRecords,
+    symptomRecords,
+    mealRecords,
+    medicationRecords,
+    labtestRecords,
+    examRecords,
+  ] = await Promise.all([
+    getAllRecords<StoolRecord>("stool_records", userId),
+    getAllRecords<SymptomRecord>("symptom_records", userId),
+    getAllRecords<MealRecord>("meal_records", userId),
+    getAllRecords<MedicationRecord>("medication_records", userId),
+    getAllRecords<LabTestRecord>("labtest_records", userId),
+    getAllRecords<ExamRecord>("exam_records", userId),
+  ]);
 
   return {
     exportedAt: new Date().toISOString(),

--- a/src/services/stool.test.ts
+++ b/src/services/stool.test.ts
@@ -54,14 +54,14 @@ describe("stool service", () => {
       expect(records[0].userId).toBe("test_user_001");
     });
 
-    it("should order by createdAt descending", async () => {
+    it("should order by date and time descending", async () => {
       const records = await stoolService.getRecent(10);
 
       if (records.length >= 2) {
         for (let i = 0; i < records.length - 1; i++) {
-          const current = new Date(records[i].createdAt).getTime();
-          const next = new Date(records[i + 1].createdAt).getTime();
-          expect(current).toBeGreaterThanOrEqual(next);
+          const currentDateTime = `${records[i].date} ${records[i].time}`;
+          const nextDateTime = `${records[i + 1].date} ${records[i + 1].time}`;
+          expect(currentDateTime >= nextDateTime).toBe(true);
         }
       }
     });

--- a/src/services/symptom.test.ts
+++ b/src/services/symptom.test.ts
@@ -78,14 +78,14 @@ describe("symptom service", () => {
       expect(records.length).toBeLessThanOrEqual(3);
     });
 
-    it("should order by createdAt descending", async () => {
+    it("should order by date and time descending", async () => {
       const records = await symptomService.getRecent(10);
 
       if (records.length >= 2) {
         for (let i = 0; i < records.length - 1; i++) {
-          const current = new Date(records[i].createdAt).getTime();
-          const next = new Date(records[i + 1].createdAt).getTime();
-          expect(current).toBeGreaterThanOrEqual(next);
+          const currentDateTime = `${records[i].date} ${records[i].time}`;
+          const nextDateTime = `${records[i + 1].date} ${records[i + 1].time}`;
+          expect(currentDateTime >= nextDateTime).toBe(true);
         }
       }
     });

--- a/src/utils/cloud.ts
+++ b/src/utils/cloud.ts
@@ -37,8 +37,8 @@ function createMemoryDatabase() {
 
 function createMemoryCollection(data: Record<string, unknown>[]) {
   let filters: Record<string, unknown> = {};
-  let sortField: string | null = null;
-  let sortOrder: "asc" | "desc" = "asc";
+  const sortFields: { field: string; order: "asc" | "desc" }[] = [];
+  let skipCount = 0;
   let limitCount: number | null = null;
 
   const query = {
@@ -47,8 +47,11 @@ function createMemoryCollection(data: Record<string, unknown>[]) {
       return query;
     },
     orderBy(field: string, order: "asc" | "desc") {
-      sortField = field;
-      sortOrder = order;
+      sortFields.push({ field, order });
+      return query;
+    },
+    skip(count: number) {
+      skipCount = count;
       return query;
     },
     limit(count: number) {
@@ -65,15 +68,20 @@ function createMemoryCollection(data: Record<string, unknown>[]) {
         });
       });
 
-      if (sortField) {
-        const field = sortField;
+      if (sortFields.length > 0) {
         result = result.sort((a, b) => {
-          const aVal = a[field];
-          const bVal = b[field];
-          if (aVal < bVal) return sortOrder === "asc" ? -1 : 1;
-          if (aVal > bVal) return sortOrder === "asc" ? 1 : -1;
+          for (const { field, order } of sortFields) {
+            const aVal = a[field];
+            const bVal = b[field];
+            if (aVal < bVal) return order === "asc" ? -1 : 1;
+            if (aVal > bVal) return order === "asc" ? 1 : -1;
+          }
           return 0;
         });
+      }
+
+      if (skipCount > 0) {
+        result = result.slice(skipCount);
       }
 
       if (limitCount !== null) {


### PR DESCRIPTION
## Summary
- Fix cloud database 20-record pagination limit with proper loops
- Add `skip()` and multi-field `orderBy()` to fake database for tests
- History page: change to single type filter with infinite scroll
- Add `getRecentBefore()` for cursor-based pagination

## Test plan
- [ ] History page loads first batch on open
- [ ] Scroll to bottom loads more records
- [ ] Pull down to refresh
- [ ] Switch type filter reloads data
- [ ] "没有更多了" shows when all loaded

🤖 Generated with [Claude Code](https://claude.ai/code)