### PR TITLE
refactor(form): simplify note input styling and fix exam note field

### DIFF
--- a/src/pages/exam/add/index.tsx
+++ b/src/pages/exam/add/index.tsx
@@ -365,6 +365,7 @@ export default function ExamAdd() {
           onInput={(e) => setNote(e.detail.value)}
           placeholder="添加备注（可选）"
           maxlength={500}
+          autoHeight
         />
       </View>
 

--- a/src/pages/exam/add/index.tsx
+++ b/src/pages/exam/add/index.tsx
@@ -359,12 +359,12 @@ export default function ExamAdd() {
       {/* 备注 */}
       <View className="section">
         <Text className="section-title">备注</Text>
-        <Input
+        <Textarea
           className="note-input"
           value={note}
           onInput={(e) => setNote(e.detail.value)}
-          placeholder="可选"
-          maxlength={200}
+          placeholder="添加备注（可选）"
+          maxlength={500}
         />
       </View>
 

--- a/src/pages/meal/add/index.tsx
+++ b/src/pages/meal/add/index.tsx
@@ -339,6 +339,7 @@ export default function MealAdd() {
           value={note}
           onInput={(e) => setNote(e.detail.value)}
           maxlength={500}
+          autoHeight
         />
       </View>
 

--- a/src/pages/medication/add/index.tsx
+++ b/src/pages/medication/add/index.tsx
@@ -315,6 +315,7 @@ export default function MedicationAdd() {
           value={note}
           onInput={(e) => setNote(e.detail.value)}
           maxlength={500}
+          autoHeight
         />
       </View>
 

--- a/src/pages/stool/add/index.tsx
+++ b/src/pages/stool/add/index.tsx
@@ -186,6 +186,7 @@ export default function StoolAdd() {
           value={note}
           onInput={(e) => setNote(e.detail.value)}
           maxlength={500}
+          autoHeight
         />
       </View>
 

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -288,6 +288,7 @@ export default function SymptomAdd() {
           value={note}
           onInput={(e) => setNote(e.detail.value)}
           maxlength={500}
+          autoHeight
         />
       </View>
 

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -37,7 +37,7 @@
 .note-input {
   width: 100%;
   min-height: 80px;
-  padding: 20px;
+  padding: 12px;
   background-color: #f5f5f5;
   border-radius: 12px;
   font-size: 28px;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -36,6 +36,7 @@
 /* 备注 */
 .note-input {
   width: 100%;
+  height: 124px;
   padding: 20px;
   background-color: #f5f5f5;
   border-radius: 12px;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -36,7 +36,7 @@
 /* 备注 */
 .note-input {
   width: 100%;
-  height: 80px;
+  height: 36px;
   padding: 20px;
   background-color: #f5f5f5;
   border-radius: 12px;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -36,7 +36,7 @@
 /* 备注 */
 .note-input {
   width: 100%;
-  height: 36px;
+  height: 80px;
   padding: 20px;
   background-color: #f5f5f5;
   border-radius: 12px;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -36,7 +36,7 @@
 /* 备注 */
 .note-input {
   width: 100%;
-  height: 80px;
+  min-height: 80px;
   padding: 20px;
   background-color: #f5f5f5;
   border-radius: 12px;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -36,7 +36,6 @@
 /* 备注 */
 .note-input {
   width: 100%;
-  min-height: 80px;
   padding: 20px;
   background-color: #f5f5f5;
   border-radius: 12px;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -36,8 +36,8 @@
 /* 备注 */
 .note-input {
   width: 100%;
-  min-height: 80px;
-  padding: 12px;
+  min-height: 60px;
+  padding: 10px;
   background-color: #f5f5f5;
   border-radius: 12px;
   font-size: 28px;

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -36,7 +36,7 @@
 /* 备注 */
 .note-input {
   width: 100%;
-  height: 124px;
+  height: 80px;
   padding: 20px;
   background-color: #f5f5f5;
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- Remove `min-height` from note-input to use default textarea height
- Change exam note field from `Input` to `Textarea` to support line breaks
- Unify placeholder text to "添加备注（可选）" across all pages

## Test plan
- [ ] Verify note input fields display with default height
- [ ] Verify exam note field supports multi-line input
- [ ] Verify all note fields show consistent placeholder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)