### PR TITLE
fix(data): rename FCP indicator to avoid fuzzy match collision

### DIFF
--- a/src/data/labtest-indicators.csv
+++ b/src/data/labtest-indicators.csv
@@ -86,4 +86,4 @@ specimen,category,nameZh,abbr,unit,refValue,refMin,refMax,aliases
 粪便,便常规,隐血,OB,,negative,,,便隐血|潜血|粪便隐血|大便隐血
 粪便,便常规,虫卵,PARA,,negative,,,寄生虫卵
 粪便,便常规,脂肪球,FAT,/HPF,,,2,脂肪滴
-粪便,炎症指标,钙卫蛋白,FCP,μg/g,,,50,粪便钙卫蛋白|Calprotectin|FC
+粪便,炎症指标,粪便钙卫蛋白,FCP,μg/g,,,50,钙卫蛋白|Calprotectin|FC

--- a/src/data/labtest-indicators.ts
+++ b/src/data/labtest-indicators.ts
@@ -419,7 +419,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "肝肾功能",
     "nameZh": "白球比",
     "abbr": "A/G",
-    "unit": "",
     "refMin": 1.2,
     "refMax": 2.5,
     "aliases": [
@@ -714,7 +713,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "凝血功能",
     "nameZh": "国际标准化比值",
     "abbr": "INR",
-    "unit": "",
     "refMin": 0.8,
     "refMax": 1.2
   },
@@ -791,7 +789,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "比重",
     "abbr": "SG",
-    "unit": "",
     "refMin": 1.004,
     "refMax": 1.03,
     "aliases": [
@@ -803,7 +800,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "pH值",
     "abbr": "pH",
-    "unit": "",
     "refMin": 4.5,
     "refMax": 8,
     "aliases": [
@@ -815,7 +811,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "白细胞",
     "abbr": "LEU",
-    "unit": "",
     "refValue": "negative",
     "aliases": [
       "尿白细胞"
@@ -826,7 +821,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "隐血",
     "abbr": "ERY",
-    "unit": "",
     "refValue": "negative",
     "aliases": [
       "尿隐血",
@@ -838,7 +832,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "亚硝酸盐",
     "abbr": "NIT",
-    "unit": "",
     "refValue": "negative"
   },
   {
@@ -846,7 +839,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "酮体",
     "abbr": "KET",
-    "unit": "",
     "refValue": "negative",
     "aliases": [
       "尿酮体"
@@ -857,7 +849,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "胆红素",
     "abbr": "BIL",
-    "unit": "",
     "refValue": "negative",
     "aliases": [
       "尿胆红素"
@@ -868,7 +859,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "尿胆原",
     "abbr": "UBG",
-    "unit": "",
     "refValue": "negative"
   },
   {
@@ -876,7 +866,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "蛋白质",
     "abbr": "PRO",
-    "unit": "",
     "refValue": "negative",
     "aliases": [
       "尿蛋白"
@@ -887,7 +876,6 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
     "category": "尿常规",
     "nameZh": "葡萄糖",
     "abbr": "GLU",
-    "unit": "",
     "refValue": "negative",
     "aliases": [
       "尿糖",
@@ -975,12 +963,12 @@ export const STANDARD_INDICATORS: StandardIndicator[] = [
   {
     "specimen": "粪便",
     "category": "炎症指标",
-    "nameZh": "钙卫蛋白",
+    "nameZh": "粪便钙卫蛋白",
     "abbr": "FCP",
     "unit": "μg/g",
     "refMax": 50,
     "aliases": [
-      "粪便钙卫蛋白",
+      "钙卫蛋白",
       "Calprotectin",
       "FC"
     ]


### PR DESCRIPTION
## Summary

- 将粪便钙卫蛋白的标准名从"钙卫蛋白"改为"粪便钙卫蛋白"
- 避免模糊匹配时被电解质"钙"误匹配（因为"钙卫蛋白"包含"钙"）

## Test plan

- [ ] 验证输入"粪便钙卫蛋白"时匹配到正确的指标

🤖 Generated with [Claude Code](https://claude.com/claude-code)