### PR TITLE
feat(labtest): add FCP chart view (#155)

### DIFF
--- a/src/components/LineChart/index.css
+++ b/src/components/LineChart/index.css
@@ -1,0 +1,4 @@
+.line-chart-canvas {
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -1,0 +1,209 @@
+import { Canvas } from "@tarojs/components";
+import Taro from "@tarojs/taro";
+import { useEffect, useRef } from "react";
+import "./index.css";
+
+export interface LineChartData {
+  date: string;
+  value: number;
+}
+
+interface LineChartProps {
+  data: LineChartData[];
+  unit?: string;
+  refMin?: number;
+  refMax?: number;
+}
+
+export default function LineChart({ data, unit, refMin, refMax }: LineChartProps) {
+  const canvasId = useRef(`line-chart-${Date.now()}`).current;
+
+  useEffect(() => {
+    if (data.length === 0) return;
+
+    const query = Taro.createSelectorQuery();
+    query
+      .select(`#${canvasId}`)
+      .fields({ node: true, size: true })
+      .exec((res) => {
+        if (!res[0]) return;
+
+        const canvas = res[0].node;
+        const ctx = canvas.getContext("2d");
+        const dpr = Taro.getSystemInfoSync().pixelRatio;
+        const width = res[0].width;
+        const height = res[0].height;
+
+        canvas.width = width * dpr;
+        canvas.height = height * dpr;
+        ctx.scale(dpr, dpr);
+
+        drawChart(ctx, width, height, data, unit, refMin, refMax);
+      });
+  }, [data, unit, refMin, refMax, canvasId]);
+
+  return <Canvas type="2d" id={canvasId} className="line-chart-canvas" />;
+}
+
+function drawChart(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  data: LineChartData[],
+  unit?: string,
+  refMin?: number,
+  refMax?: number,
+) {
+  const padding = { top: 20, right: 16, bottom: 50, left: 50 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+
+  // Clear canvas
+  ctx.clearRect(0, 0, width, height);
+
+  if (data.length === 0) return;
+
+  // Calculate value range
+  const values = data.map((d) => d.value);
+  let minValue = Math.min(...values);
+  let maxValue = Math.max(...values);
+
+  // Include reference range in scale
+  if (refMin !== undefined) minValue = Math.min(minValue, refMin);
+  if (refMax !== undefined) maxValue = Math.max(maxValue, refMax);
+
+  // Add 10% padding to value range
+  const valueRange = maxValue - minValue || 1;
+  minValue = minValue - valueRange * 0.1;
+  maxValue = maxValue + valueRange * 0.1;
+
+  // Helper to convert value to Y coordinate
+  const valueToY = (v: number) => {
+    return padding.top + chartHeight - ((v - minValue) / (maxValue - minValue)) * chartHeight;
+  };
+
+  // Helper to convert index to X coordinate
+  const indexToX = (i: number) => {
+    if (data.length === 1) return padding.left + chartWidth / 2;
+    return padding.left + (i / (data.length - 1)) * chartWidth;
+  };
+
+  // Draw reference range area
+  if (refMin !== undefined && refMax !== undefined) {
+    const y1 = valueToY(refMax);
+    const y2 = valueToY(refMin);
+    ctx.fillStyle = "rgba(7, 193, 96, 0.1)";
+    ctx.fillRect(padding.left, y1, chartWidth, y2 - y1);
+
+    // Draw reference range lines
+    ctx.strokeStyle = "rgba(7, 193, 96, 0.3)";
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+
+    ctx.beginPath();
+    ctx.moveTo(padding.left, y1);
+    ctx.lineTo(padding.left + chartWidth, y1);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(padding.left, y2);
+    ctx.lineTo(padding.left + chartWidth, y2);
+    ctx.stroke();
+
+    ctx.setLineDash([]);
+  }
+
+  // Draw Y axis grid lines and labels
+  ctx.strokeStyle = "#e8e8e8";
+  ctx.lineWidth = 1;
+  ctx.fillStyle = "#999";
+  ctx.font = "10px sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+
+  const gridLines = 5;
+  for (let i = 0; i <= gridLines; i++) {
+    const value = minValue + ((maxValue - minValue) * i) / gridLines;
+    const y = valueToY(value);
+
+    // Label
+    ctx.fillText(value.toFixed(1), padding.left - 8, y);
+
+    // Grid line
+    ctx.beginPath();
+    ctx.moveTo(padding.left, y);
+    ctx.lineTo(width - padding.right, y);
+    ctx.stroke();
+  }
+
+  // Draw unit label
+  if (unit) {
+    ctx.fillStyle = "#999";
+    ctx.font = "10px sans-serif";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    ctx.fillText(unit, padding.left, 4);
+  }
+
+  // Draw line
+  ctx.strokeStyle = "#07c160";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  data.forEach((point, i) => {
+    const x = indexToX(i);
+    const y = valueToY(point.value);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  });
+  ctx.stroke();
+
+  // Draw data points
+  data.forEach((point, i) => {
+    const x = indexToX(i);
+    const y = valueToY(point.value);
+
+    // Determine if point is out of reference range
+    const isOutOfRange =
+      (refMin !== undefined && point.value < refMin) ||
+      (refMax !== undefined && point.value > refMax);
+
+    ctx.beginPath();
+    ctx.arc(x, y, 4, 0, Math.PI * 2);
+    ctx.fillStyle = isOutOfRange ? "#fa5151" : "#07c160";
+    ctx.fill();
+
+    // White border
+    ctx.strokeStyle = "#fff";
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  });
+
+  // Draw X axis labels (dates)
+  ctx.fillStyle = "#999";
+  ctx.font = "10px sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+
+  // Show first, last, and some middle labels
+  const labelIndices = getLabelIndices(data.length);
+  labelIndices.forEach((i) => {
+    const x = indexToX(i);
+    const dateLabel = data[i].date.slice(5); // MM-DD
+    ctx.fillText(dateLabel, x, height - padding.bottom + 8);
+  });
+}
+
+function getLabelIndices(length: number): number[] {
+  if (length <= 1) return [0];
+  if (length <= 5) return Array.from({ length }, (_, i) => i);
+
+  const indices = [0, length - 1];
+  const step = Math.ceil((length - 2) / 3);
+  for (let i = step; i < length - 1; i += step) {
+    indices.push(i);
+  }
+  return [...new Set(indices)].sort((a, b) => a - b);
+}

--- a/src/pages/history/index.css
+++ b/src/pages/history/index.css
@@ -229,3 +229,38 @@
   color: #999;
   font-size: 28px;
 }
+
+/* 数据列表 */
+.stats-data-list {
+  margin-top: 24px;
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 8px 24px;
+}
+
+.stats-data-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 0;
+  border-bottom: 1px solid #f5f5f5;
+}
+
+.stats-data-item:last-child {
+  border-bottom: none;
+}
+
+.stats-data-date {
+  font-size: 28px;
+  color: #666;
+}
+
+.stats-data-value {
+  font-size: 28px;
+  color: #07c160;
+  font-weight: 500;
+}
+
+.stats-data-value.out-of-range {
+  color: #fa5151;
+}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -163,6 +163,12 @@ export default function History() {
     setLabtestChartData([]);
     const { startDate, endDate } = getEffectiveDateRange();
     loadInitial(type, startDate, endDate);
+    // Load chart data for stool and labtest
+    if (type === "stool") {
+      loadStatsData(startDate, endDate);
+    } else if (type === "labtest") {
+      loadLabtestStatsData();
+    }
   };
 
   const loadStatsData = useCallback(async (startDate: string, endDate: string) => {

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -332,6 +332,20 @@ export default function History() {
           />
         )}
       </View>
+      {labtestChartData.length > 0 && (
+        <View className="stats-data-list">
+          {[...labtestChartData].reverse().map((item, index) => (
+            <View key={index} className="stats-data-item">
+              <Text className="stats-data-date">{item.date}</Text>
+              <Text
+                className={`stats-data-value ${FCP_INDICATOR.refMax !== undefined && item.value > FCP_INDICATOR.refMax ? "out-of-range" : ""}`}
+              >
+                {item.value} {FCP_INDICATOR.unit}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
     </View>
   );
 

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -197,13 +197,7 @@ export default function History() {
     setLabtestStatsLoading(true);
     try {
       // Fetch all labtest records
-      const allRecords = await labTestService.getByDateRangeBefore(
-        "1900-01-01",
-        formatDate(),
-        "9999-12-31",
-        "23:59",
-        1000,
-      );
+      const allRecords = await labTestService.getByDateRange("1900-01-01", formatDate());
 
       // Extract FCP indicator values
       const chartData: LineChartData[] = [];

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -145,6 +145,12 @@ export default function History() {
   useDidShow(() => {
     const { startDate, endDate } = getEffectiveDateRange();
     loadInitial(selectedType, startDate, endDate);
+    // Load chart data for stool and labtest
+    if (selectedType === "stool") {
+      loadStatsData(startDate, endDate);
+    } else if (selectedType === "labtest") {
+      loadLabtestStatsData();
+    }
   });
 
   const handleRefresh = useCallback(async () => {

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -26,7 +26,7 @@ const FCP_INDICATOR = {
 
 type StoolViewTab = "score" | "count" | "records";
 type LabtestViewTab = "chart" | "records";
-type DateRangePreset = "7" | "30" | "365" | "custom";
+type DateRangePreset = "7" | "30" | "365" | "1095" | "custom";
 
 const PAGE_SIZE = 50;
 
@@ -406,6 +406,12 @@ export default function History() {
           onClick={() => handleDateRangePresetChange("365")}
         >
           <Text>一年</Text>
+        </View>
+        <View
+          className={`date-range-option ${dateRangePreset === "1095" ? "active" : ""}`}
+          onClick={() => handleDateRangePresetChange("1095")}
+        >
+          <Text>三年</Text>
         </View>
         <View
           className={`date-range-option ${dateRangePreset === "custom" ? "active" : ""}`}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -149,7 +149,7 @@ export default function History() {
     if (selectedType === "stool") {
       loadStatsData(startDate, endDate);
     } else if (selectedType === "labtest") {
-      loadLabtestStatsData();
+      loadLabtestStatsData(startDate, endDate);
     }
   });
 
@@ -173,7 +173,7 @@ export default function History() {
     if (type === "stool") {
       loadStatsData(startDate, endDate);
     } else if (type === "labtest") {
-      loadLabtestStatsData();
+      loadLabtestStatsData(startDate, endDate);
     }
   };
 
@@ -199,11 +199,11 @@ export default function History() {
     }
   }, []);
 
-  const loadLabtestStatsData = useCallback(async () => {
+  const loadLabtestStatsData = useCallback(async (startDate: string, endDate: string) => {
     setLabtestStatsLoading(true);
     try {
-      // Fetch all labtest records
-      const allRecords = await labTestService.getByDateRange("1900-01-01", formatDate());
+      // Fetch labtest records in date range
+      const allRecords = await labTestService.getByDateRange(startDate, endDate);
 
       // Extract FCP indicator values
       const chartData: LineChartData[] = [];
@@ -243,7 +243,8 @@ export default function History() {
     if (tab === labtestViewTab) return;
     setLabtestViewTab(tab);
     if (tab === "chart" && labtestChartData.length === 0) {
-      loadLabtestStatsData();
+      const { startDate, endDate } = getEffectiveDateRange();
+      loadLabtestStatsData(startDate, endDate);
     }
   };
 
@@ -260,6 +261,9 @@ export default function History() {
       if (selectedType === "stool" && stoolViewTab !== "records") {
         loadStatsData(startDate, endDate);
       }
+      if (selectedType === "labtest" && labtestViewTab === "chart") {
+        loadLabtestStatsData(startDate, endDate);
+      }
     }
   };
 
@@ -268,6 +272,9 @@ export default function History() {
     loadInitial(selectedType, start, end);
     if (selectedType === "stool" && stoolViewTab !== "records") {
       loadStatsData(start, end);
+    }
+    if (selectedType === "labtest" && labtestViewTab === "chart") {
+      loadLabtestStatsData(start, end);
     }
   };
 

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -26,7 +26,7 @@ const FCP_INDICATOR = {
 
 type StoolViewTab = "score" | "count" | "records";
 type LabtestViewTab = "chart" | "records";
-type DateRangePreset = "7" | "30" | "365" | "1095" | "custom";
+type DateRangePreset = "7" | "30" | "365" | "all" | "custom";
 
 const PAGE_SIZE = 50;
 
@@ -137,6 +137,9 @@ export default function History() {
   const getEffectiveDateRange = useCallback(() => {
     if (dateRangePreset === "custom") {
       return { startDate: customStartDate, endDate: customEndDate };
+    }
+    if (dateRangePreset === "all") {
+      return { startDate: "1900-01-01", endDate: formatDate() };
     }
     const days = parseInt(dateRangePreset, 10);
     return { startDate: getDateDaysAgo(days), endDate: formatDate() };
@@ -435,10 +438,10 @@ export default function History() {
           <Text>一年</Text>
         </View>
         <View
-          className={`date-range-option ${dateRangePreset === "1095" ? "active" : ""}`}
-          onClick={() => handleDateRangePresetChange("1095")}
+          className={`date-range-option ${dateRangePreset === "all" ? "active" : ""}`}
+          onClick={() => handleDateRangePresetChange("all")}
         >
-          <Text>三年</Text>
+          <Text>所有</Text>
         </View>
         <View
           className={`date-range-option ${dateRangePreset === "custom" ? "active" : ""}`}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -57,7 +57,9 @@ export default function History() {
   // Stats view state
   const [stoolViewTab, setStoolViewTab] = useState<StoolViewTab>("score");
   const [labtestViewTab, setLabtestViewTab] = useState<LabtestViewTab>("chart");
-  const [dateRangePreset, setDateRangePreset] = useState<DateRangePreset>("7");
+  const [dateRangePreset, setDateRangePreset] = useState<DateRangePreset>(() => {
+    return Taro.getStorageSync("history_date_range_preset") || "7";
+  });
   const [customStartDate, setCustomStartDate] = useState(() => getDateDaysAgo(7));
   const [customEndDate, setCustomEndDate] = useState(() => formatDate());
   const [startCalendarVisible, setStartCalendarVisible] = useState(false);
@@ -253,10 +255,16 @@ export default function History() {
 
   const handleDateRangePresetChange = (preset: DateRangePreset) => {
     setDateRangePreset(preset);
+    Taro.setStorageSync("history_date_range_preset", preset);
     if (preset !== "custom") {
-      const days = parseInt(preset, 10);
-      const startDate = getDateDaysAgo(days);
+      let startDate: string;
       const endDate = formatDate();
+      if (preset === "all") {
+        startDate = "1900-01-01";
+      } else {
+        const days = parseInt(preset, 10);
+        startDate = getDateDaysAgo(days);
+      }
       setCustomStartDate(startDate);
       setCustomEndDate(endDate);
       setRecords([]);

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -145,41 +145,6 @@ export default function History() {
     return { startDate: getDateDaysAgo(days), endDate: formatDate() };
   }, [dateRangePreset, customStartDate, customEndDate]);
 
-  useDidShow(() => {
-    const { startDate, endDate } = getEffectiveDateRange();
-    loadInitial(selectedType, startDate, endDate);
-    // Load chart data for stool and labtest
-    if (selectedType === "stool") {
-      loadStatsData(startDate, endDate);
-    } else if (selectedType === "labtest") {
-      loadLabtestStatsData(startDate, endDate);
-    }
-  });
-
-  const handleRefresh = useCallback(async () => {
-    const { startDate, endDate } = getEffectiveDateRange();
-    await loadInitial(selectedType, startDate, endDate);
-  }, [loadInitial, selectedType, getEffectiveDateRange]);
-
-  const handleTypeChange = (type: RecordType) => {
-    if (type === selectedType) return;
-    setSelectedType(type);
-    Taro.setStorageSync("history_selected_type", type);
-    setRecords([]);
-    setStoolViewTab("score");
-    setLabtestViewTab("chart");
-    // Reset labtest stats when switching types
-    setLabtestChartData([]);
-    const { startDate, endDate } = getEffectiveDateRange();
-    loadInitial(type, startDate, endDate);
-    // Load chart data for stool and labtest
-    if (type === "stool") {
-      loadStatsData(startDate, endDate);
-    } else if (type === "labtest") {
-      loadLabtestStatsData(startDate, endDate);
-    }
-  };
-
   const loadStatsData = useCallback(async (startDate: string, endDate: string) => {
     setStatsLoading(true);
     try {
@@ -232,6 +197,41 @@ export default function History() {
       setLabtestStatsLoading(false);
     }
   }, []);
+
+  useDidShow(() => {
+    const { startDate, endDate } = getEffectiveDateRange();
+    loadInitial(selectedType, startDate, endDate);
+    // Load chart data for stool and labtest
+    if (selectedType === "stool") {
+      loadStatsData(startDate, endDate);
+    } else if (selectedType === "labtest") {
+      loadLabtestStatsData(startDate, endDate);
+    }
+  });
+
+  const handleRefresh = useCallback(async () => {
+    const { startDate, endDate } = getEffectiveDateRange();
+    await loadInitial(selectedType, startDate, endDate);
+  }, [loadInitial, selectedType, getEffectiveDateRange]);
+
+  const handleTypeChange = (type: RecordType) => {
+    if (type === selectedType) return;
+    setSelectedType(type);
+    Taro.setStorageSync("history_selected_type", type);
+    setRecords([]);
+    setStoolViewTab("score");
+    setLabtestViewTab("chart");
+    // Reset labtest stats when switching types
+    setLabtestChartData([]);
+    const { startDate, endDate } = getEffectiveDateRange();
+    loadInitial(type, startDate, endDate);
+    // Load chart data for stool and labtest
+    if (type === "stool") {
+      loadStatsData(startDate, endDate);
+    } else if (type === "labtest") {
+      loadLabtestStatsData(startDate, endDate);
+    }
+  };
 
   const handleStoolViewTabChange = (tab: StoolViewTab) => {
     if (tab === stoolViewTab) return;

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -7,14 +7,25 @@ import { stoolService } from "../../services/stool";
 import { medicationService } from "../../services/medication";
 import { labTestService } from "../../services/labtest";
 import { examService } from "../../services/exam";
+import { findStandardIndicator } from "../../services/labtest-standards";
 import { formatDisplayDate, getWeekday, formatDate } from "../../utils/date";
 import RecordItem, { AnyRecord } from "../../components/RecordItem";
 import CalendarPopup from "../../components/CalendarPopup";
 import BarChart from "../../components/BarChart";
-import { RecordType, RECORD_TYPE_OPTIONS } from "../../types";
+import LineChart, { LineChartData } from "../../components/LineChart";
+import { RecordType, RECORD_TYPE_OPTIONS, LabTestRecord } from "../../types";
 import "./index.css";
 
+// 粪便钙卫蛋白指标配置
+const FCP_INDICATOR = {
+  nameZh: "粪便钙卫蛋白",
+  abbr: "FCP",
+  unit: "μg/g",
+  refMax: 50,
+};
+
 type StoolViewTab = "score" | "count" | "records";
+type LabtestViewTab = "chart" | "records";
 type DateRangePreset = "7" | "30" | "365" | "custom";
 
 const PAGE_SIZE = 50;
@@ -45,6 +56,7 @@ export default function History() {
 
   // Stats view state
   const [stoolViewTab, setStoolViewTab] = useState<StoolViewTab>("score");
+  const [labtestViewTab, setLabtestViewTab] = useState<LabtestViewTab>("chart");
   const [dateRangePreset, setDateRangePreset] = useState<DateRangePreset>("7");
   const [customStartDate, setCustomStartDate] = useState(() => getDateDaysAgo(7));
   const [customEndDate, setCustomEndDate] = useState(() => formatDate());
@@ -53,6 +65,10 @@ export default function History() {
   const [countData, setCountData] = useState<{ date: string; value: number }[]>([]);
   const [scoreData, setScoreData] = useState<{ date: string; value: number }[]>([]);
   const [statsLoading, setStatsLoading] = useState(false);
+
+  // Labtest stats state
+  const [labtestChartData, setLabtestChartData] = useState<LineChartData[]>([]);
+  const [labtestStatsLoading, setLabtestStatsLoading] = useState(false);
 
   const cursorRef = useRef({ date: "9999-12-31", time: "23:59" });
   const dateRangeRef = useRef({ startDate: "", endDate: "" });
@@ -142,6 +158,9 @@ export default function History() {
     Taro.setStorageSync("history_selected_type", type);
     setRecords([]);
     setStoolViewTab("score");
+    setLabtestViewTab("chart");
+    // Reset labtest stats when switching types
+    setLabtestChartData([]);
     const { startDate, endDate } = getEffectiveDateRange();
     loadInitial(type, startDate, endDate);
   };
@@ -168,12 +187,57 @@ export default function History() {
     }
   }, []);
 
+  const loadLabtestStatsData = useCallback(async () => {
+    setLabtestStatsLoading(true);
+    try {
+      // Fetch all labtest records
+      const allRecords = await labTestService.getByDateRangeBefore(
+        "1900-01-01",
+        formatDate(),
+        "9999-12-31",
+        "23:59",
+        1000,
+      );
+
+      // Extract FCP indicator values
+      const chartData: LineChartData[] = [];
+      (allRecords as LabTestRecord[]).forEach((record) => {
+        record.indicators.forEach((ind) => {
+          const matched = findStandardIndicator(ind.name, record.specimen);
+          if (matched && matched.nameZh === FCP_INDICATOR.nameZh) {
+            const numValue = parseFloat(ind.value);
+            if (!isNaN(numValue)) {
+              chartData.push({ date: record.date, value: numValue });
+            }
+          }
+        });
+      });
+
+      // Sort by date ascending
+      chartData.sort((a, b) => a.date.localeCompare(b.date));
+      setLabtestChartData(chartData);
+    } catch (error) {
+      console.error("加载化验统计数据失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setLabtestStatsLoading(false);
+    }
+  }, []);
+
   const handleStoolViewTabChange = (tab: StoolViewTab) => {
     if (tab === stoolViewTab) return;
     setStoolViewTab(tab);
     if (tab !== "records" && countData.length === 0) {
       const { startDate, endDate } = getEffectiveDateRange();
       loadStatsData(startDate, endDate);
+    }
+  };
+
+  const handleLabtestViewTabChange = (tab: LabtestViewTab) => {
+    if (tab === labtestViewTab) return;
+    setLabtestViewTab(tab);
+    if (tab === "chart" && labtestChartData.length === 0) {
+      loadLabtestStatsData();
     }
   };
 
@@ -242,6 +306,85 @@ export default function History() {
       </View>
     </View>
   );
+
+  const renderLabtestStatsView = () => (
+    <View className="stats-view">
+      <View className="stats-header">
+        <Text className="stats-title">{FCP_INDICATOR.nameZh}趋势</Text>
+        <Text className="stats-range">
+          参考范围: &lt;{FCP_INDICATOR.refMax} {FCP_INDICATOR.unit}
+        </Text>
+      </View>
+      <View className="stats-chart-container">
+        {labtestStatsLoading ? (
+          <View className="stats-loading">
+            <Text>加载中...</Text>
+          </View>
+        ) : labtestChartData.length === 0 ? (
+          <View className="stats-empty">
+            <Text>暂无数据</Text>
+          </View>
+        ) : (
+          <LineChart
+            data={labtestChartData}
+            unit={FCP_INDICATOR.unit}
+            refMax={FCP_INDICATOR.refMax}
+          />
+        )}
+      </View>
+    </View>
+  );
+
+  const renderRecordsList = () => {
+    if (loading) {
+      return <View className="loading">加载中...</View>;
+    }
+    if (records.length === 0) {
+      return (
+        <View className="empty">
+          <Text className="empty-text">暂无记录</Text>
+        </View>
+      );
+    }
+    return (
+      <ScrollView
+        className="records-scroll"
+        scrollY
+        refresherEnabled
+        refresherTriggered={loading}
+        onRefresherRefresh={handleRefresh}
+        onScrollToLower={handleLoadMore}
+        lowerThreshold={100}
+      >
+        <View className="records-list">
+          {groupedRecords.map((group) => (
+            <View key={group.date} className="date-group">
+              <View className="date-header">
+                <Text className="date-text">
+                  {formatDisplayDate(group.date)} {getWeekday(group.date)}
+                </Text>
+              </View>
+              <View className="date-records">
+                {group.records.map((record) => (
+                  <RecordItem key={record._id} record={record} />
+                ))}
+              </View>
+            </View>
+          ))}
+        </View>
+        {loadingMore && (
+          <View className="loading-more">
+            <Text>加载中...</Text>
+          </View>
+        )}
+        {!hasMore && records.length > 0 && (
+          <View className="no-more">
+            <Text>没有更多了</Text>
+          </View>
+        )}
+      </ScrollView>
+    );
+  };
 
   return (
     <View className="history-page">
@@ -348,53 +491,31 @@ export default function History() {
         </View>
       )}
 
+      {selectedType === "labtest" && (
+        <View className="view-mode-tabs">
+          <View
+            className={`view-mode-tab ${labtestViewTab === "chart" ? "active" : ""}`}
+            onClick={() => handleLabtestViewTabChange("chart")}
+          >
+            <Text>钙卫蛋白趋势</Text>
+          </View>
+          <View
+            className={`view-mode-tab ${labtestViewTab === "records" ? "active" : ""}`}
+            onClick={() => handleLabtestViewTabChange("records")}
+          >
+            <Text>原始数据</Text>
+          </View>
+        </View>
+      )}
+
       {selectedType === "stool" && stoolViewTab === "score" ? (
         renderChartView("每日肠道健康得分", scoreData, 10, true)
       ) : selectedType === "stool" && stoolViewTab === "count" ? (
         renderChartView("每日排便次数", countData)
-      ) : loading ? (
-        <View className="loading">加载中...</View>
-      ) : records.length === 0 ? (
-        <View className="empty">
-          <Text className="empty-text">暂无记录</Text>
-        </View>
+      ) : selectedType === "labtest" && labtestViewTab === "chart" ? (
+        renderLabtestStatsView()
       ) : (
-        <ScrollView
-          className="records-scroll"
-          scrollY
-          refresherEnabled
-          refresherTriggered={loading}
-          onRefresherRefresh={handleRefresh}
-          onScrollToLower={handleLoadMore}
-          lowerThreshold={100}
-        >
-          <View className="records-list">
-            {groupedRecords.map((group) => (
-              <View key={group.date} className="date-group">
-                <View className="date-header">
-                  <Text className="date-text">
-                    {formatDisplayDate(group.date)} {getWeekday(group.date)}
-                  </Text>
-                </View>
-                <View className="date-records">
-                  {group.records.map((record) => (
-                    <RecordItem key={record._id} record={record} />
-                  ))}
-                </View>
-              </View>
-            ))}
-          </View>
-          {loadingMore && (
-            <View className="loading-more">
-              <Text>加载中...</Text>
-            </View>
-          )}
-          {!hasMore && records.length > 0 && (
-            <View className="no-more">
-              <Text>没有更多了</Text>
-            </View>
-          )}
-        </ScrollView>
+        renderRecordsList()
       )}
     </View>
   );

--- a/src/services/labtest-standards.ts
+++ b/src/services/labtest-standards.ts
@@ -96,3 +96,21 @@ export function normalizeIndicator(
 export function normalizeIndicators(indicators: LabTestIndicator[], specimen?: SpecimenType) {
   return indicators.map((ind) => normalizeIndicator(ind, specimen));
 }
+
+/**
+ * 搜索标准指标（模糊匹配名称、缩写、别名）
+ * @param query 搜索关键字
+ * @param limit 最大返回数量
+ */
+export function searchIndicators(query: string, limit = 20): StandardIndicator[] {
+  if (!query.trim()) return [];
+
+  const q = query.trim().toLowerCase();
+
+  return STANDARD_INDICATORS.filter((ind) => {
+    if (ind.nameZh.toLowerCase().includes(q)) return true;
+    if (ind.abbr.toLowerCase().includes(q)) return true;
+    if (ind.aliases?.some((alias) => alias.toLowerCase().includes(q))) return true;
+    return false;
+  }).slice(0, limit);
+}

--- a/src/services/labtest-standards.ts
+++ b/src/services/labtest-standards.ts
@@ -96,21 +96,3 @@ export function normalizeIndicator(
 export function normalizeIndicators(indicators: LabTestIndicator[], specimen?: SpecimenType) {
   return indicators.map((ind) => normalizeIndicator(ind, specimen));
 }
-
-/**
- * 搜索标准指标（模糊匹配名称、缩写、别名）
- * @param query 搜索关键字
- * @param limit 最大返回数量
- */
-export function searchIndicators(query: string, limit = 20): StandardIndicator[] {
-  if (!query.trim()) return [];
-
-  const q = query.trim().toLowerCase();
-
-  return STANDARD_INDICATORS.filter((ind) => {
-    if (ind.nameZh.toLowerCase().includes(q)) return true;
-    if (ind.abbr.toLowerCase().includes(q)) return true;
-    if (ind.aliases?.some((alias) => alias.toLowerCase().includes(q))) return true;
-    return false;
-  }).slice(0, limit);
-}


### PR DESCRIPTION
## Summary
- Add LineChart component with reference range support
- Add labtest stats view to history page (records/stats toggle)
- Fixed indicator: 粪便钙卫蛋白 (FCP) with reference range <50 μg/g

## Test plan
- [ ] Navigate to history page > labtest tab
- [ ] Verify "记录/统计" tabs appear
- [ ] Click "统计" tab
- [ ] Verify FCP trend chart displays with reference range

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)