### PR TITLE
fix(labtest): handle indicator values with comparison symbols (#169)

### DIFF
--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -192,7 +192,9 @@ function drawChart(
   const labelIndices = getLabelIndices(data.length);
   labelIndices.forEach((i) => {
     const x = indexToX(i);
-    const dateLabel = data[i].date.slice(5); // MM-DD
+    const date = data[i].date;
+    // Format: YY/MM/DD
+    const dateLabel = `${date.slice(2, 4)}/${date.slice(5, 7)}/${date.slice(8, 10)}`;
     ctx.fillText(dateLabel, x, height - padding.bottom + 8);
   });
 }

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -6,6 +6,7 @@ import "./index.css";
 export interface LineChartData {
   date: string;
   value: number;
+  displayValue?: string; // Original display value (e.g., ">1800")
 }
 
 interface LineChartProps {

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -181,9 +181,11 @@ export default function History() {
         record.indicators.forEach((ind) => {
           const matched = findStandardIndicator(ind.name, record.specimen);
           if (matched && matched.nameZh === FCP_INDICATOR.nameZh) {
-            const numValue = parseFloat(ind.value);
+            // Parse value, handling comparison symbols like >1800 or <10
+            const valueStr = ind.value.trim();
+            const numValue = parseFloat(valueStr.replace(/^[<>]/, ""));
             if (!isNaN(numValue)) {
-              chartData.push({ date: record.date, value: numValue });
+              chartData.push({ date: record.date, value: numValue, displayValue: valueStr });
             }
           }
         });
@@ -364,7 +366,7 @@ export default function History() {
               <Text
                 className={`stats-data-value ${FCP_INDICATOR.refMax !== undefined && item.value > FCP_INDICATOR.refMax ? "out-of-range" : ""}`}
               >
-                {item.value} {FCP_INDICATOR.unit}
+                {item.displayValue || item.value} {FCP_INDICATOR.unit}
               </Text>
             </View>
           ))}


### PR DESCRIPTION
## Summary
- Parse values like `>1800` or `<10` by stripping comparison prefix
- Preserve original display value for data list

## Test plan
- [ ] Add a labtest record with value like `>1800`
- [ ] Verify it appears on the chart
- [ ] Verify data list shows original value with symbol

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)