### PR TITLE
feat(labtest): add indicator selector for chart view

### DIFF
--- a/src/components/IndicatorPicker/index.css
+++ b/src/components/IndicatorPicker/index.css
@@ -1,0 +1,99 @@
+.indicator-picker-mask {
+  position: fixed;
+  inset: 0;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.indicator-picker {
+  width: 100%;
+  max-height: 70vh;
+  background-color: #fff;
+  border-radius: 24px 24px 0 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.indicator-picker-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px;
+  border-bottom: 1px solid #eee;
+}
+
+.indicator-picker-title {
+  font-size: 32px;
+  font-weight: 600;
+  color: #333;
+}
+
+.indicator-picker-close {
+  font-size: 28px;
+  color: #999;
+  padding: 8px;
+}
+
+.indicator-picker-search {
+  padding: 16px 24px;
+}
+
+.indicator-search-input {
+  width: 100%;
+  height: 72px;
+  padding: 0 24px;
+  font-size: 28px;
+  border: 1px solid #eee;
+  border-radius: 12px;
+  background-color: #f5f5f5;
+}
+
+.indicator-picker-list {
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: calc(24px + env(safe-area-inset-bottom));
+}
+
+.indicator-item {
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  border-bottom: 1px solid #f5f5f5;
+}
+
+.indicator-item:active {
+  background-color: #f5f5f5;
+}
+
+.indicator-name {
+  font-size: 28px;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.indicator-meta {
+  font-size: 24px;
+  color: #999;
+}
+
+.indicator-picker-empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 48px;
+  color: #999;
+  font-size: 28px;
+}
+
+.indicator-picker-hint {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 48px;
+  color: #999;
+  font-size: 26px;
+  text-align: center;
+}

--- a/src/components/IndicatorPicker/index.tsx
+++ b/src/components/IndicatorPicker/index.tsx
@@ -1,0 +1,87 @@
+import { View, Text, Input, ScrollView } from "@tarojs/components";
+import { useState } from "react";
+import { searchIndicators, StandardIndicator } from "../../services/labtest-standards";
+import "./index.css";
+
+interface IndicatorPickerProps {
+  visible: boolean;
+  onSelect: (indicator: StandardIndicator) => void;
+  onClose: () => void;
+}
+
+export default function IndicatorPicker({ visible, onSelect, onClose }: IndicatorPickerProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<StandardIndicator[]>([]);
+
+  if (!visible) return null;
+
+  const handleInput = (e: { detail: { value: string } }) => {
+    const value = e.detail.value;
+    setQuery(value);
+    setResults(searchIndicators(value));
+  };
+
+  const handleSelect = (indicator: StandardIndicator) => {
+    onSelect(indicator);
+    setQuery("");
+    setResults([]);
+    onClose();
+  };
+
+  const handleClose = () => {
+    setQuery("");
+    setResults([]);
+    onClose();
+  };
+
+  return (
+    <View className="indicator-picker-mask" onClick={handleClose}>
+      <View className="indicator-picker" onClick={(e) => e.stopPropagation()}>
+        <View className="indicator-picker-header">
+          <Text className="indicator-picker-title">选择指标</Text>
+          <Text className="indicator-picker-close" onClick={handleClose}>
+            关闭
+          </Text>
+        </View>
+
+        <View className="indicator-picker-search">
+          <Input
+            className="indicator-search-input"
+            placeholder="搜索指标名称或缩写"
+            value={query}
+            onInput={handleInput}
+            focus={visible}
+          />
+        </View>
+
+        <ScrollView className="indicator-picker-list" scrollY>
+          {query === "" ? (
+            <View className="indicator-picker-hint">
+              <Text>输入指标名称或缩写进行搜索{"\n"}如：白细胞、WBC、CRP</Text>
+            </View>
+          ) : results.length === 0 ? (
+            <View className="indicator-picker-empty">
+              <Text>未找到匹配的指标</Text>
+            </View>
+          ) : (
+            results.map((indicator) => (
+              <View
+                key={`${indicator.specimen}-${indicator.nameZh}`}
+                className="indicator-item"
+                onClick={() => handleSelect(indicator)}
+              >
+                <Text className="indicator-name">
+                  {indicator.nameZh} ({indicator.abbr})
+                </Text>
+                <Text className="indicator-meta">
+                  {indicator.specimen} · {indicator.category}
+                  {indicator.unit ? ` · ${indicator.unit}` : ""}
+                </Text>
+              </View>
+            ))
+          )}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}

--- a/src/pages/history/index.css
+++ b/src/pages/history/index.css
@@ -264,3 +264,15 @@
 .stats-data-value.out-of-range {
   color: #fa5151;
 }
+
+/* 指标选择器 */
+.indicator-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.indicator-selector-arrow {
+  font-size: 20px;
+  color: #999;
+}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -7,8 +7,9 @@ import { stoolService } from "../../services/stool";
 import { medicationService } from "../../services/medication";
 import { labTestService } from "../../services/labtest";
 import { examService } from "../../services/exam";
-import { findStandardIndicator } from "../../services/labtest-standards";
+import { findStandardIndicator, StandardIndicator } from "../../services/labtest-standards";
 import { formatDisplayDate, getWeekday, formatDate } from "../../utils/date";
+import IndicatorPicker from "../../components/IndicatorPicker";
 import RecordItem, { AnyRecord } from "../../components/RecordItem";
 import CalendarPopup from "../../components/CalendarPopup";
 import BarChart from "../../components/BarChart";
@@ -16,8 +17,10 @@ import LineChart, { LineChartData } from "../../components/LineChart";
 import { RecordType, RECORD_TYPE_OPTIONS, LabTestRecord } from "../../types";
 import "./index.css";
 
-// 粪便钙卫蛋白指标配置
-const FCP_INDICATOR = {
+// 默认指标：粪便钙卫蛋白
+const DEFAULT_INDICATOR: StandardIndicator = {
+  specimen: "粪便",
+  category: "炎症标志物",
   nameZh: "粪便钙卫蛋白",
   abbr: "FCP",
   unit: "μg/g",
@@ -71,6 +74,11 @@ export default function History() {
   // Labtest stats state
   const [labtestChartData, setLabtestChartData] = useState<LineChartData[]>([]);
   const [labtestStatsLoading, setLabtestStatsLoading] = useState(false);
+  const [selectedIndicator, setSelectedIndicator] = useState<StandardIndicator>(() => {
+    const saved = Taro.getStorageSync("history_selected_indicator");
+    return saved ? JSON.parse(saved) : DEFAULT_INDICATOR;
+  });
+  const [indicatorPickerVisible, setIndicatorPickerVisible] = useState(false);
 
   const cursorRef = useRef({ date: "9999-12-31", time: "23:59" });
   const dateRangeRef = useRef({ startDate: "", endDate: "" });
@@ -169,38 +177,41 @@ export default function History() {
     }
   }, []);
 
-  const loadLabtestStatsData = useCallback(async (startDate: string, endDate: string) => {
-    setLabtestStatsLoading(true);
-    try {
-      // Fetch labtest records in date range
-      const allRecords = await labTestService.getByDateRange(startDate, endDate);
+  const loadLabtestStatsData = useCallback(
+    async (startDate: string, endDate: string, indicator: StandardIndicator) => {
+      setLabtestStatsLoading(true);
+      try {
+        // Fetch labtest records in date range
+        const allRecords = await labTestService.getByDateRange(startDate, endDate);
 
-      // Extract FCP indicator values
-      const chartData: LineChartData[] = [];
-      (allRecords as LabTestRecord[]).forEach((record) => {
-        record.indicators.forEach((ind) => {
-          const matched = findStandardIndicator(ind.name, record.specimen);
-          if (matched && matched.nameZh === FCP_INDICATOR.nameZh) {
-            // Parse value, handling comparison symbols like >1800 or <10
-            const valueStr = ind.value.trim();
-            const numValue = parseFloat(valueStr.replace(/^[<>]/, ""));
-            if (!isNaN(numValue)) {
-              chartData.push({ date: record.date, value: numValue, displayValue: valueStr });
+        // Extract indicator values
+        const chartData: LineChartData[] = [];
+        (allRecords as LabTestRecord[]).forEach((record) => {
+          record.indicators.forEach((ind) => {
+            const matched = findStandardIndicator(ind.name, record.specimen);
+            if (matched && matched.nameZh === indicator.nameZh) {
+              // Parse value, handling comparison symbols like >1800 or <10
+              const valueStr = ind.value.trim();
+              const numValue = parseFloat(valueStr.replace(/^[<>]/, ""));
+              if (!isNaN(numValue)) {
+                chartData.push({ date: record.date, value: numValue, displayValue: valueStr });
+              }
             }
-          }
+          });
         });
-      });
 
-      // Sort by date ascending
-      chartData.sort((a, b) => a.date.localeCompare(b.date));
-      setLabtestChartData(chartData);
-    } catch (error) {
-      console.error("加载化验统计数据失败:", error);
-      Taro.showToast({ title: "加载失败", icon: "none" });
-    } finally {
-      setLabtestStatsLoading(false);
-    }
-  }, []);
+        // Sort by date ascending
+        chartData.sort((a, b) => a.date.localeCompare(b.date));
+        setLabtestChartData(chartData);
+      } catch (error) {
+        console.error("加载化验统计数据失败:", error);
+        Taro.showToast({ title: "加载失败", icon: "none" });
+      } finally {
+        setLabtestStatsLoading(false);
+      }
+    },
+    [],
+  );
 
   useDidShow(() => {
     const { startDate, endDate } = getEffectiveDateRange();
@@ -209,7 +220,7 @@ export default function History() {
     if (selectedType === "stool") {
       loadStatsData(startDate, endDate);
     } else if (selectedType === "labtest") {
-      loadLabtestStatsData(startDate, endDate);
+      loadLabtestStatsData(startDate, endDate, selectedIndicator);
     }
   });
 
@@ -233,7 +244,7 @@ export default function History() {
     if (type === "stool") {
       loadStatsData(startDate, endDate);
     } else if (type === "labtest") {
-      loadLabtestStatsData(startDate, endDate);
+      loadLabtestStatsData(startDate, endDate, selectedIndicator);
     }
   };
 
@@ -251,8 +262,16 @@ export default function History() {
     setLabtestViewTab(tab);
     if (tab === "chart" && labtestChartData.length === 0) {
       const { startDate, endDate } = getEffectiveDateRange();
-      loadLabtestStatsData(startDate, endDate);
+      loadLabtestStatsData(startDate, endDate, selectedIndicator);
     }
+  };
+
+  const handleIndicatorSelect = (indicator: StandardIndicator) => {
+    setSelectedIndicator(indicator);
+    Taro.setStorageSync("history_selected_indicator", JSON.stringify(indicator));
+    setLabtestChartData([]);
+    const { startDate, endDate } = getEffectiveDateRange();
+    loadLabtestStatsData(startDate, endDate, indicator);
   };
 
   const handleDateRangePresetChange = (preset: DateRangePreset) => {
@@ -275,7 +294,7 @@ export default function History() {
         loadStatsData(startDate, endDate);
       }
       if (selectedType === "labtest" && labtestViewTab === "chart") {
-        loadLabtestStatsData(startDate, endDate);
+        loadLabtestStatsData(startDate, endDate, selectedIndicator);
       }
     }
   };
@@ -287,7 +306,7 @@ export default function History() {
       loadStatsData(start, end);
     }
     if (selectedType === "labtest" && labtestViewTab === "chart") {
-      loadLabtestStatsData(start, end);
+      loadLabtestStatsData(start, end, selectedIndicator);
     }
   };
 
@@ -333,47 +352,79 @@ export default function History() {
     </View>
   );
 
-  const renderLabtestStatsView = () => (
-    <View className="stats-view">
-      <View className="stats-header">
-        <Text className="stats-title">{FCP_INDICATOR.nameZh}趋势</Text>
-        <Text className="stats-range">
-          参考范围: &lt;{FCP_INDICATOR.refMax} {FCP_INDICATOR.unit}
-        </Text>
-      </View>
-      <View className="stats-chart-container">
-        {labtestStatsLoading ? (
-          <View className="stats-loading">
-            <Text>加载中...</Text>
+  const renderLabtestStatsView = () => {
+    const refRange =
+      selectedIndicator.refMin !== undefined && selectedIndicator.refMax !== undefined
+        ? `${selectedIndicator.refMin}-${selectedIndicator.refMax}`
+        : selectedIndicator.refMax !== undefined
+          ? `<${selectedIndicator.refMax}`
+          : selectedIndicator.refMin !== undefined
+            ? `>${selectedIndicator.refMin}`
+            : "";
+
+    const isOutOfRange = (value: number) => {
+      if (selectedIndicator.refMin !== undefined && value < selectedIndicator.refMin) return true;
+      if (selectedIndicator.refMax !== undefined && value > selectedIndicator.refMax) return true;
+      return false;
+    };
+
+    return (
+      <View className="stats-view">
+        <View className="stats-header">
+          <View
+            className="stats-title indicator-selector"
+            onClick={() => setIndicatorPickerVisible(true)}
+          >
+            <Text>
+              {selectedIndicator.nameZh} ({selectedIndicator.abbr})
+            </Text>
+            <Text className="indicator-selector-arrow">▼</Text>
           </View>
-        ) : labtestChartData.length === 0 ? (
-          <View className="stats-empty">
-            <Text>暂无数据</Text>
-          </View>
-        ) : (
-          <LineChart
-            data={labtestChartData}
-            unit={FCP_INDICATOR.unit}
-            refMax={FCP_INDICATOR.refMax}
-          />
-        )}
-      </View>
-      {labtestChartData.length > 0 && (
-        <View className="stats-data-list">
-          {[...labtestChartData].reverse().map((item, index) => (
-            <View key={index} className="stats-data-item">
-              <Text className="stats-data-date">{item.date}</Text>
-              <Text
-                className={`stats-data-value ${FCP_INDICATOR.refMax !== undefined && item.value > FCP_INDICATOR.refMax ? "out-of-range" : ""}`}
-              >
-                {item.displayValue || item.value} {FCP_INDICATOR.unit}
-              </Text>
-            </View>
-          ))}
+          {refRange && (
+            <Text className="stats-range">
+              参考范围: {refRange} {selectedIndicator.unit}
+            </Text>
+          )}
         </View>
-      )}
-    </View>
-  );
+        <View className="stats-chart-container">
+          {labtestStatsLoading ? (
+            <View className="stats-loading">
+              <Text>加载中...</Text>
+            </View>
+          ) : labtestChartData.length === 0 ? (
+            <View className="stats-empty">
+              <Text>暂无数据</Text>
+            </View>
+          ) : (
+            <LineChart
+              data={labtestChartData}
+              unit={selectedIndicator.unit}
+              refMin={selectedIndicator.refMin}
+              refMax={selectedIndicator.refMax}
+            />
+          )}
+        </View>
+        {labtestChartData.length > 0 && (
+          <View className="stats-data-list">
+            {[...labtestChartData].reverse().map((item, index) => (
+              <View key={index} className="stats-data-item">
+                <Text className="stats-data-date">{item.date}</Text>
+                <Text className={`stats-data-value ${isOutOfRange(item.value) ? "out-of-range" : ""}`}>
+                  {item.displayValue || item.value} {selectedIndicator.unit}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        <IndicatorPicker
+          visible={indicatorPickerVisible}
+          onSelect={handleIndicatorSelect}
+          onClose={() => setIndicatorPickerVisible(false)}
+        />
+      </View>
+    );
+  };
 
   const renderRecordsList = () => {
     if (loading) {

--- a/src/services/labtest-standards.ts
+++ b/src/services/labtest-standards.ts
@@ -96,3 +96,21 @@ export function normalizeIndicator(
 export function normalizeIndicators(indicators: LabTestIndicator[], specimen?: SpecimenType) {
   return indicators.map((ind) => normalizeIndicator(ind, specimen));
 }
+
+/**
+ * 搜索标准指标（模糊匹配名称、缩写、别名）
+ * @param query 搜索关键字
+ * @param limit 最大返回数量
+ */
+export function searchIndicators(query: string, limit = 20): StandardIndicator[] {
+  if (!query.trim()) return [];
+
+  const q = query.trim().toLowerCase();
+
+  return STANDARD_INDICATORS.filter((ind) => {
+    if (ind.nameZh.toLowerCase().includes(q)) return true;
+    if (ind.abbr.toLowerCase().includes(q)) return true;
+    if (ind.aliases?.some((alias) => alias.toLowerCase().includes(q))) return true;
+    return false;
+  }).slice(0, limit);
+}


### PR DESCRIPTION
## Summary
- Add IndicatorPicker component with fuzzy search (name, abbreviation, aliases)
- Replace fixed FCP indicator with user-selectable indicator
- Persist selected indicator to local storage
- Display appropriate reference range based on selected indicator

Closes #168

## Test plan
- [ ] Open labtest tab in history page
- [ ] Tap indicator name to open picker
- [ ] Search for indicator by name (e.g., "白细胞"), abbreviation (e.g., "WBC"), or alias
- [ ] Select an indicator and verify chart updates
- [ ] Leave and return to page - selected indicator should persist
- [ ] Verify reference range displays correctly for indicators with refMin, refMax, or both

🤖 Generated with [Claude Code](https://claude.com/claude-code)