### PR TITLE
fix(chart): increase top padding for event labels and remove auto-scroll

### DIFF
--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -98,7 +98,7 @@ function drawChart(
   propMaxValue?: number,
   events: ChartEvent[] = [],
 ): { event: ChartEvent; x: number }[] {
-  const padding = { top: 20, right: 8, bottom: 40, left: 16 };
+  const padding = { top: 30, right: 8, bottom: 40, left: 16 };
   const chartWidth = width - padding.left - padding.right;
   const chartHeight = height - padding.top - padding.bottom;
 

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -220,7 +220,7 @@ function drawChart(
     ctx.stroke();
 
     // Draw two-line label: date on top, description below
-    const date = eventGroup[0].date.slice(5); // MM-DD
+    const date = eventGroup[0].date.slice(2); // YY-MM-DD
     const label = eventGroup.map((e) => e.description).join(" / ");
     ctx.fillText(date, x, 2);
     ctx.fillText(label, x, 14);

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -87,7 +87,7 @@ function drawChart(
   refMax?: number,
   events: ChartEvent[] = [],
 ): { event: ChartEvent; x: number }[] {
-  const padding = { top: 20, right: 16, bottom: 50, left: 50 };
+  const padding = { top: 30, right: 16, bottom: 50, left: 50 };
   const chartWidth = width - padding.left - padding.right;
   const chartHeight = height - padding.top - padding.bottom;
 

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -231,7 +231,7 @@ function drawChart(
     ctx.stroke();
 
     // Draw two-line label: date on top, description below
-    const date = eventGroup[0].date.slice(5); // MM-DD
+    const date = eventGroup[0].date.slice(2); // YY-MM-DD
     const label = eventGroup.map((e) => e.description).join(" / ");
     ctx.fillText(date, x, 2);
     ctx.fillText(label, x, 14);

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -409,12 +409,7 @@ export default function History() {
             <Text>暂无数据</Text>
           </View>
         ) : (
-          <BarChart
-            data={data}
-            maxValue={maxValue}
-            events={events}
-            onEventTap={handleEventTap}
-          />
+          <BarChart data={data} maxValue={maxValue} events={events} onEventTap={handleEventTap} />
         )}
       </View>
     </View>
@@ -634,7 +629,7 @@ export default function History() {
         onClose={() => setEndCalendarVisible(false)}
       />
 
-      <ScrollView className="type-filter" scrollX scrollIntoView={`type-${selectedType}`}>
+      <ScrollView className="type-filter" scrollX>
         {RECORD_TYPE_OPTIONS.map((option) => (
           <View
             key={option.value}


### PR DESCRIPTION
## Summary
- Increase chart top padding from 20 to 30 to prevent two-line event labels from overlapping with chart content
- Remove scrollIntoView on type filter to prevent jarring scroll jumps when selecting types

## Test plan
- [ ] Verify event labels no longer overlap with chart content
- [ ] Verify type filter no longer auto-scrolls when selecting a type

🤖 Generated with [Claude Code](https://claude.com/claude-code)