### PR TITLE
feat(history): improve data page UI and scoring system

### DIFF
--- a/cloudfunctions/stool-stats/index.js
+++ b/cloudfunctions/stool-stats/index.js
@@ -37,10 +37,12 @@ exports.main = async (event) => {
     hasMore = data.length === MAX_LIMIT;
   }
 
-  // Bristol type to score: 1→3, 2→4, 3→5, 4→5, 5→4, 6→3, 7→1
-  const BRISTOL_SCORES = [0, 3, 4, 5, 5, 4, 3, 1];
+  // Bristol type to score: 1→2, 2→4, 3→6, 4→6, 5→4, 6→2, 7→0
+  const BRISTOL_SCORES = [0, 2, 4, 6, 6, 4, 2, 0];
   const getBristolScore = (bristol) => BRISTOL_SCORES[bristol] || 0;
-  const getCountScore = (count) => Math.max(0, 6 - count);
+  // Count score: 1-2→4, 3→3, 4→2, 5→1, 6+→0
+  const COUNT_SCORES = [0, 4, 4, 3, 2, 1, 0];
+  const getCountScore = (count) => COUNT_SCORES[Math.min(count, 6)] || 0;
 
   // 按日期聚合统计
   const dailyData = {};

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -260,17 +260,34 @@ function drawChart(
     labelInterval = 30; // Monthly
   }
 
-  // Find the second-to-last interval label index
+  // Find the second-to-last interval label index and check if it would overlap with last label
   const secondToLastIntervalIndex = Math.floor((data.length - 2) / labelInterval) * labelInterval;
+  const lastIndex = data.length - 1;
+
+  // Calculate minimum spacing needed (label width ~50px for YY-MM-DD)
+  const labelWidth = 50;
+  const secondToLastX = startX + secondToLastIntervalIndex * (barWidth + barGap) + barWidth / 2;
+  const lastX = startX + lastIndex * (barWidth + barGap) + barWidth / 2;
+  const wouldOverlap = secondToLastIntervalIndex !== 0 && lastX - secondToLastX < labelWidth;
 
   data.forEach((item, index) => {
-    // Skip second-to-last interval label to avoid overlap with last label
-    if (index === secondToLastIntervalIndex && index !== 0) return;
+    // Skip second-to-last interval label only if it would overlap with last label
+    if (index === secondToLastIntervalIndex && wouldOverlap) return;
 
     // Show first, last, and interval labels
     if (index === 0 || index === data.length - 1 || index % labelInterval === 0) {
       const x = startX + index * (barWidth + barGap) + barWidth / 2;
-      const dateLabel = item.date.slice(5); // MM-DD
+      // Format: YY-MM-DD
+      const dateLabel = item.date.slice(2);
+
+      // Align first label left, last label right, others center
+      if (index === 0) {
+        ctx.textAlign = "left";
+      } else if (index === data.length - 1) {
+        ctx.textAlign = "right";
+      } else {
+        ctx.textAlign = "center";
+      }
       ctx.fillText(dateLabel, x, height - padding.bottom + 8);
     }
   });

--- a/src/components/BristolIcon/index.tsx
+++ b/src/components/BristolIcon/index.tsx
@@ -121,7 +121,7 @@ export default function BristolIcon({ type, size = 48 }: BristolIconProps) {
   return (
     <Image
       src={svgToDataUri(BRISTOL_SVGS[type])}
-      style={{ width: size, height: size }}
+      style={{ width: `${size}px`, height: `${size}px` }}
       mode="aspectFit"
     />
   );

--- a/src/components/EventFormPopup/index.css
+++ b/src/components/EventFormPopup/index.css
@@ -47,11 +47,13 @@
 
 .event-form-input {
   width: 100%;
-  padding: 20px 24px;
+  height: 80px;
+  padding: 0 24px;
   background-color: #f5f5f5;
   border-radius: 12px;
   font-size: 28px;
   color: #333;
+  box-sizing: border-box;
 }
 
 .event-form-actions {

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -105,9 +105,13 @@ function drawChart(
   if (refMin !== undefined) minValue = Math.min(minValue, refMin);
   if (refMax !== undefined) maxValue = Math.max(maxValue, refMax);
 
-  // Add 10% padding to value range
+  // Start from 0 unless there are negative values
+  if (minValue >= 0) {
+    minValue = 0;
+  }
+
+  // Add 10% padding to top
   const valueRange = maxValue - minValue || 1;
-  minValue = minValue - valueRange * 0.1;
   maxValue = maxValue + valueRange * 0.1;
 
   // Helper to convert value to Y coordinate
@@ -192,13 +196,13 @@ function drawChart(
     ctx.stroke();
   }
 
-  // Draw unit label
+  // Draw unit label above Y axis
   if (unit) {
     ctx.fillStyle = "#999";
     ctx.font = "10px sans-serif";
-    ctx.textAlign = "left";
-    ctx.textBaseline = "top";
-    ctx.fillText(unit, padding.left, 4);
+    ctx.textAlign = "right";
+    ctx.textBaseline = "bottom";
+    ctx.fillText(unit, padding.left - 8, padding.top - 12);
   }
 
   // Draw event lines and collect positions

--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -24,6 +24,8 @@
 .record-feeling {
   font-size: 28px;
   margin-right: 8px;
+  display: flex;
+  align-items: center;
 }
 
 .record-severity {

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -105,7 +105,7 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
         return (
           <>
             <View className="record-feeling">
-              <BristolIcon type={record.type} size={24} />
+              <BristolIcon type={record.type} size={18} />
             </View>
             <Text className="record-desc">
               {getStoolAmountLabel(record.amount)}

--- a/src/pages/history/index.css
+++ b/src/pages/history/index.css
@@ -10,46 +10,28 @@
   height: 0;
 }
 
-/* 类型筛选 */
-.type-filter {
+/* 类型标签页 */
+.type-tabs {
   display: flex;
-  white-space: nowrap;
-  padding: 24px;
   background-color: #fff;
+  border-bottom: 1px solid #eee;
 }
 
-.type-option {
-  display: inline-flex;
+.type-tab {
+  flex: 1;
+  display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 20px;
-  border-radius: 20px;
-  background-color: #f5f5f5;
-  border: 2px solid transparent;
-  margin-right: 16px;
+  justify-content: center;
+  padding: 16px 0;
+  border-bottom: 4px solid transparent;
 }
 
-.type-option:last-child {
-  margin-right: 0;
+.type-tab.active {
+  border-bottom-color: #5fcf9a;
 }
 
-.type-option.active {
-  background-color: #e8f7ee;
-  border-color: #5fcf9a;
-}
-
-.type-icon {
-  font-size: 28px;
-}
-
-.type-label {
-  font-size: 26px;
-  color: #666;
-}
-
-.type-option.active .type-label {
-  color: #5fcf9a;
-  font-weight: 500;
+.type-tab-icon {
+  font-size: 40px;
 }
 
 /* 加载状态 */
@@ -143,51 +125,52 @@
   padding: 24px;
 }
 
-/* 日期范围选择器 */
-.date-range-selector {
+/* 图表内日期范围选择器 */
+.chart-date-range {
   display: flex;
-  gap: 16px;
-  padding: 24px;
-  background-color: #fff;
-}
-
-.date-range-option {
-  flex: 1;
-  display: flex;
-  justify-content: center;
   align-items: center;
-  padding: 16px 0;
-  border-radius: 12px;
-  background-color: #fff;
-  font-size: 26px;
-  color: #666;
+  gap: 12px;
+  margin-top: 8px;
 }
 
-.date-range-option.active {
-  background-color: #5fcf9a;
-  color: #fff;
+.date-range-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background-color: #f5f5f5;
+  font-size: 24px;
+  color: #333;
+}
+
+.date-range-arrow {
+  font-size: 18px;
+  color: #999;
+}
+
+.date-range-display {
+  font-size: 24px;
+  color: #999;
 }
 
 /* 自定义日期范围 */
 .custom-date-range {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 16px;
-  padding: 0 24px 24px;
-  background-color: #fff;
+  gap: 8px;
 }
 
 .date-picker {
-  padding: 16px 24px;
-  border-radius: 12px;
-  background-color: #fff;
-  font-size: 26px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background-color: #f5f5f5;
+  font-size: 24px;
   color: #333;
 }
 
 .date-range-separator {
-  font-size: 26px;
+  font-size: 24px;
   color: #999;
 }
 
@@ -203,10 +186,32 @@
   margin-bottom: 8px;
 }
 
+.stats-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .stats-title {
   font-size: 32px;
   font-weight: 600;
   color: #333;
+}
+
+.stats-help-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #e8e8e8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  color: #666;
+}
+
+.stats-help-btn:active {
+  background-color: #ddd;
 }
 
 .add-event-btn {
@@ -221,7 +226,8 @@
   background-color: #e8e8e8;
 }
 
-.stats-range {
+.stats-range,
+.stats-ref-range {
   font-size: 24px;
   color: #999;
 }
@@ -268,12 +274,12 @@
 }
 
 .stats-data-date {
-  font-size: 28px;
+  font-size: 24px;
   color: #666;
 }
 
 .stats-data-value {
-  font-size: 28px;
+  font-size: 24px;
   color: #5fcf9a;
   font-weight: 500;
 }
@@ -292,4 +298,61 @@
 .indicator-selector-arrow {
   font-size: 20px;
   color: #999;
+}
+
+/* 帮助弹窗 */
+.help-popup-mask {
+  position: fixed;
+  inset: 0;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.help-popup {
+  width: 80%;
+  max-width: 560px;
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 32px;
+}
+
+.help-popup-title {
+  display: block;
+  font-size: 32px;
+  font-weight: 600;
+  color: #333;
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.help-popup-section {
+  margin-bottom: 16px;
+}
+
+.help-popup-subtitle {
+  display: block;
+  font-size: 26px;
+  font-weight: 500;
+  color: #333;
+  margin-bottom: 8px;
+}
+
+.help-popup-item {
+  display: block;
+  font-size: 24px;
+  color: #666;
+  line-height: 1.6;
+}
+
+.help-popup-btn {
+  margin-top: 24px;
+  padding: 16px;
+  background-color: #5fcf9a;
+  border-radius: 8px;
+  text-align: center;
+  font-size: 28px;
+  color: #fff;
 }

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -50,6 +50,19 @@ function getDateDaysAgo(days: number): string {
   return formatDate(date);
 }
 
+const DATE_RANGE_LABELS: Record<DateRangePreset, string> = {
+  "30": "近一月",
+  "90": "近三月",
+  "365": "近一年",
+  "1095": "近三年",
+  all: "所有",
+  custom: "自定义",
+};
+
+function getTypeLabel(type: RecordType): string {
+  return RECORD_TYPE_OPTIONS.find((opt) => opt.value === type)?.label || "";
+}
+
 export default function History() {
   const [selectedType, setSelectedType] = useState<RecordType>(() => {
     return Taro.getStorageSync("history_selected_type") || "meal";
@@ -236,6 +249,9 @@ export default function History() {
   }, []);
 
   useDidShow(() => {
+    // Update navigation bar title
+    Taro.setNavigationBarTitle({ title: `${getTypeLabel(selectedType)}数据` });
+
     // Load events (lightweight, always refresh)
     setEvents(eventService.getAll());
 
@@ -262,6 +278,7 @@ export default function History() {
     if (type === selectedType) return;
     setSelectedType(type);
     Taro.setStorageSync("history_selected_type", type);
+    Taro.setNavigationBarTitle({ title: `${getTypeLabel(type)}数据` });
     setRecords([]);
     setStoolViewTab("score");
     setLabtestViewTab("chart");
@@ -326,6 +343,16 @@ export default function History() {
         loadLabtestStatsData(startDate, endDate, selectedIndicator);
       }
     }
+  };
+
+  const showDateRangePicker = () => {
+    const presets: DateRangePreset[] = ["30", "90", "365", "1095", "all", "custom"];
+    const labels = presets.map((p) => DATE_RANGE_LABELS[p]);
+    Taro.showActionSheet({ itemList: labels })
+      .then((res) => {
+        handleDateRangePresetChange(presets[res.tapIndex]);
+      })
+      .catch(() => {});
   };
 
   const handleCustomDateChange = (start: string, end: string) => {
@@ -398,22 +425,55 @@ export default function History() {
 
   const { startDate: effectiveStartDate, endDate: effectiveEndDate } = getEffectiveDateRange();
 
+  const renderDateRangeSelector = () => (
+    <View className="chart-date-range">
+      <View className="date-range-btn" onClick={showDateRangePicker}>
+        <Text>{DATE_RANGE_LABELS[dateRangePreset]}</Text>
+        <Text className="date-range-arrow">▼</Text>
+      </View>
+      {dateRangePreset === "custom" && (
+        <View className="custom-date-range">
+          <View className="date-picker" onClick={() => setStartCalendarVisible(true)}>
+            <Text>{customStartDate}</Text>
+          </View>
+          <Text className="date-range-separator">~</Text>
+          <View className="date-picker" onClick={() => setEndCalendarVisible(true)}>
+            <Text>{customEndDate}</Text>
+          </View>
+        </View>
+      )}
+      {dateRangePreset !== "custom" && (
+        <Text className="date-range-display">
+          {effectiveStartDate} ~ {effectiveEndDate}
+        </Text>
+      )}
+    </View>
+  );
+
+  const [scoreHelpVisible, setScoreHelpVisible] = useState(false);
+
   const renderChartView = (
     title: string,
     data: { date: string; value: number }[],
     maxValue?: number,
+    showHelp?: boolean,
   ) => (
     <View className="stats-view">
       <View className="stats-header">
         <View className="stats-header-row">
-          <Text className="stats-title">{title}</Text>
+          <View className="stats-title-row">
+            <Text className="stats-title">{title}</Text>
+            {showHelp && (
+              <View className="stats-help-btn" onClick={() => setScoreHelpVisible(true)}>
+                <Text>?</Text>
+              </View>
+            )}
+          </View>
           <View className="add-event-btn" onClick={handleAddEvent}>
             <Text>+ 事件</Text>
           </View>
         </View>
-        <Text className="stats-range">
-          {effectiveStartDate} ~ {effectiveEndDate}
-        </Text>
+        {renderDateRangeSelector()}
       </View>
       <View className="stats-chart-container">
         {statsLoading ? (
@@ -464,11 +524,7 @@ export default function History() {
               <Text>+ 事件</Text>
             </View>
           </View>
-          {refRange && (
-            <Text className="stats-range">
-              参考范围: {refRange} {selectedIndicator.unit}
-            </Text>
-          )}
+          {renderDateRangeSelector()}
         </View>
         <View className="stats-chart-container">
           {labtestStatsLoading ? (
@@ -567,57 +623,6 @@ export default function History() {
 
   return (
     <View className="history-page">
-      <View className="date-range-selector">
-        <View
-          className={`date-range-option ${dateRangePreset === "30" ? "active" : ""}`}
-          onClick={() => handleDateRangePresetChange("30")}
-        >
-          <Text>一月</Text>
-        </View>
-        <View
-          className={`date-range-option ${dateRangePreset === "90" ? "active" : ""}`}
-          onClick={() => handleDateRangePresetChange("90")}
-        >
-          <Text>三月</Text>
-        </View>
-        <View
-          className={`date-range-option ${dateRangePreset === "365" ? "active" : ""}`}
-          onClick={() => handleDateRangePresetChange("365")}
-        >
-          <Text>一年</Text>
-        </View>
-        <View
-          className={`date-range-option ${dateRangePreset === "1095" ? "active" : ""}`}
-          onClick={() => handleDateRangePresetChange("1095")}
-        >
-          <Text>三年</Text>
-        </View>
-        <View
-          className={`date-range-option ${dateRangePreset === "all" ? "active" : ""}`}
-          onClick={() => handleDateRangePresetChange("all")}
-        >
-          <Text>所有</Text>
-        </View>
-        <View
-          className={`date-range-option ${dateRangePreset === "custom" ? "active" : ""}`}
-          onClick={() => handleDateRangePresetChange("custom")}
-        >
-          <Text>自定义</Text>
-        </View>
-      </View>
-
-      {dateRangePreset === "custom" && (
-        <View className="custom-date-range">
-          <View className="date-picker" onClick={() => setStartCalendarVisible(true)}>
-            <Text>{customStartDate}</Text>
-          </View>
-          <Text className="date-range-separator">至</Text>
-          <View className="date-picker" onClick={() => setEndCalendarVisible(true)}>
-            <Text>{customEndDate}</Text>
-          </View>
-        </View>
-      )}
-
       <CalendarPopup
         visible={startCalendarVisible}
         value={customStartDate}
@@ -645,19 +650,17 @@ export default function History() {
         onClose={() => setEndCalendarVisible(false)}
       />
 
-      <ScrollView className="type-filter" scrollX>
+      <View className="type-tabs">
         {RECORD_TYPE_OPTIONS.map((option) => (
           <View
             key={option.value}
-            id={`type-${option.value}`}
-            className={`type-option ${selectedType === option.value ? "active" : ""}`}
+            className={`type-tab ${selectedType === option.value ? "active" : ""}`}
             onClick={() => handleTypeChange(option.value)}
           >
-            <Text className="type-icon">{option.icon}</Text>
-            <Text className="type-label">{option.label}</Text>
+            <Text className="type-tab-icon">{option.icon}</Text>
           </View>
         ))}
-      </ScrollView>
+      </View>
 
       {selectedType === "stool" && (
         <View className="view-mode-tabs">
@@ -688,7 +691,7 @@ export default function History() {
             className={`view-mode-tab ${labtestViewTab === "chart" ? "active" : ""}`}
             onClick={() => handleLabtestViewTabChange("chart")}
           >
-            <Text>钙卫蛋白趋势</Text>
+            <Text>指标趋势</Text>
           </View>
           <View
             className={`view-mode-tab ${labtestViewTab === "records" ? "active" : ""}`}
@@ -700,7 +703,7 @@ export default function History() {
       )}
 
       {selectedType === "stool" && stoolViewTab === "score"
-        ? renderChartView("每日排便得分", scoreData, 10)
+        ? renderChartView("每日排便得分", scoreData, 10, true)
         : selectedType === "stool" && stoolViewTab === "count"
           ? renderChartView("每日排便次数", countData)
           : selectedType === "labtest" && labtestViewTab === "chart"
@@ -713,6 +716,34 @@ export default function History() {
         onConfirm={handleEventFormConfirm}
         onClose={handleEventFormClose}
       />
+
+      {scoreHelpVisible && (
+        <View className="help-popup-mask" onClick={() => setScoreHelpVisible(false)}>
+          <View className="help-popup" onClick={(e) => e.stopPropagation()}>
+            <Text className="help-popup-title">排便得分计算规则</Text>
+            <View className="help-popup-section">
+              <Text className="help-popup-subtitle">Bristol 分型得分：</Text>
+              <Text className="help-popup-item">3-4型（正常）：6分</Text>
+              <Text className="help-popup-item">2型或5型：4分</Text>
+              <Text className="help-popup-item">1型或6型：2分</Text>
+              <Text className="help-popup-item">7型（水样）：0分</Text>
+            </View>
+            <View className="help-popup-section">
+              <Text className="help-popup-subtitle">次数得分：</Text>
+              <Text className="help-popup-item">
+                1-2次：4分；3次：3分；4次：2分；5次：1分；6+次：0分
+              </Text>
+            </View>
+            <View className="help-popup-section">
+              <Text className="help-popup-item">每日得分 = 平均分型得分 + 次数得分</Text>
+              <Text className="help-popup-item">得分越高越好，满分 10 分</Text>
+            </View>
+            <View className="help-popup-btn" onClick={() => setScoreHelpVisible(false)}>
+              <Text>知道了</Text>
+            </View>
+          </View>
+        </View>
+      )}
     </View>
   );
 }

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -492,15 +492,6 @@ export default function History() {
   );
 
   const renderLabtestStatsView = () => {
-    const refRange =
-      selectedIndicator.refMin !== undefined && selectedIndicator.refMax !== undefined
-        ? `${selectedIndicator.refMin}-${selectedIndicator.refMax}`
-        : selectedIndicator.refMax !== undefined
-          ? `<${selectedIndicator.refMax}`
-          : selectedIndicator.refMin !== undefined
-            ? `>${selectedIndicator.refMin}`
-            : "";
-
     const isOutOfRange = (value: number) => {
       if (selectedIndicator.refMin !== undefined && value < selectedIndicator.refMin) return true;
       if (selectedIndicator.refMax !== undefined && value > selectedIndicator.refMax) return true;


### PR DESCRIPTION
## Summary
- Reorganize filter layout: type tabs (icon-only) at top, date range selector in chart area
- Dynamic page title based on selected record type (e.g., "排便数据", "化验数据")
- Add help button explaining stool score calculation with custom popup
- Update stool scoring: Bristol scores [0,2,4,6,6,4,2,0], count scores [0,4,4,3,2,1,0]
- Chart improvements: Y-axis starts from 0, date format YY-MM-DD, smart label overlap detection
- Move unit label above Y-axis in LineChart
- Fix EventFormPopup input width overflow
- Reduce BristolIcon size in record list

## Test plan
- [ ] Verify type tabs display correctly with icons only
- [ ] Check page title changes when switching record types
- [ ] Test stool score help popup displays correctly with line breaks
- [ ] Verify chart date labels don't overflow and handle overlap properly
- [ ] Check LineChart Y-axis starts from 0
- [ ] Test EventFormPopup description input width is correct
- [ ] Deploy cloud function stool-stats manually (requires WeChat DevTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)