### PR TITLE
refactor: break up large files (>500 lines)

### DIFF
--- a/src/pages/history/components/LabtestChartView.tsx
+++ b/src/pages/history/components/LabtestChartView.tsx
@@ -1,0 +1,98 @@
+import { View, Text } from "@tarojs/components";
+import LineChart, { LineChartData } from "../../../components/LineChart";
+import IndicatorPicker from "../../../components/IndicatorPicker";
+import type { StandardIndicator } from "../../../services/labtest-standards";
+import type { ChartEvent } from "../../../types";
+
+interface LabtestChartViewProps {
+  chartData: LineChartData[];
+  loading: boolean;
+  selectedIndicator: StandardIndicator;
+  indicatorPickerVisible: boolean;
+  events: ChartEvent[];
+  onIndicatorSelect: (indicator: StandardIndicator) => void;
+  onIndicatorPickerOpen: () => void;
+  onIndicatorPickerClose: () => void;
+  onEventTap: (event: ChartEvent) => void;
+  onAddEvent: () => void;
+  dateRangeSelector: React.ReactNode;
+}
+
+export default function LabtestChartView({
+  chartData,
+  loading,
+  selectedIndicator,
+  indicatorPickerVisible,
+  events,
+  onIndicatorSelect,
+  onIndicatorPickerOpen,
+  onIndicatorPickerClose,
+  onEventTap,
+  onAddEvent,
+  dateRangeSelector,
+}: LabtestChartViewProps) {
+  const isOutOfRange = (value: number) => {
+    if (selectedIndicator.refMin !== undefined && value < selectedIndicator.refMin) return true;
+    if (selectedIndicator.refMax !== undefined && value > selectedIndicator.refMax) return true;
+    return false;
+  };
+
+  return (
+    <View className="stats-view">
+      <View className="stats-header">
+        <View className="stats-header-row">
+          <View className="stats-title indicator-selector" onClick={onIndicatorPickerOpen}>
+            <Text>
+              {selectedIndicator.nameZh} ({selectedIndicator.abbr})
+            </Text>
+            <Text className="indicator-selector-arrow">▼</Text>
+          </View>
+          <View className="add-event-btn" onClick={onAddEvent}>
+            <Text>+ 事件</Text>
+          </View>
+        </View>
+        {dateRangeSelector}
+      </View>
+      <View className="stats-chart-container">
+        {loading ? (
+          <View className="stats-loading">
+            <Text>加载中...</Text>
+          </View>
+        ) : chartData.length === 0 ? (
+          <View className="stats-empty">
+            <Text>暂无数据</Text>
+          </View>
+        ) : (
+          <LineChart
+            data={chartData}
+            unit={selectedIndicator.unit}
+            refMin={selectedIndicator.refMin}
+            refMax={selectedIndicator.refMax}
+            events={events}
+            onEventTap={onEventTap}
+          />
+        )}
+      </View>
+      {chartData.length > 0 && (
+        <View className="stats-data-list">
+          {[...chartData].reverse().map((item, index) => (
+            <View key={index} className="stats-data-item">
+              <Text className="stats-data-date">{item.date}</Text>
+              <Text
+                className={`stats-data-value ${isOutOfRange(item.value) ? "out-of-range" : ""}`}
+              >
+                {item.displayValue || item.value} {selectedIndicator.unit}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      <IndicatorPicker
+        visible={indicatorPickerVisible}
+        onSelect={onIndicatorSelect}
+        onClose={onIndicatorPickerClose}
+      />
+    </View>
+  );
+}

--- a/src/pages/history/components/RecordsList.tsx
+++ b/src/pages/history/components/RecordsList.tsx
@@ -1,0 +1,83 @@
+import { View, Text, ScrollView } from "@tarojs/components";
+import RecordItem, { AnyRecord } from "../../../components/RecordItem";
+import { formatDisplayDate, getWeekday } from "../../../utils/date";
+
+interface RecordsListProps {
+  records: AnyRecord[];
+  loading: boolean;
+  loadingMore: boolean;
+  hasMore: boolean;
+  onRefresh: () => void;
+  onLoadMore: () => void;
+}
+
+export default function RecordsList({
+  records,
+  loading,
+  loadingMore,
+  hasMore,
+  onRefresh,
+  onLoadMore,
+}: RecordsListProps) {
+  if (loading) {
+    return <View className="loading">加载中...</View>;
+  }
+
+  if (records.length === 0) {
+    return (
+      <View className="empty">
+        <Text className="empty-text">暂无记录</Text>
+      </View>
+    );
+  }
+
+  // Group records by date
+  const groupedRecords: { date: string; records: AnyRecord[] }[] = [];
+  let currentDate = "";
+  records.forEach((record) => {
+    if (record.date !== currentDate) {
+      currentDate = record.date;
+      groupedRecords.push({ date: record.date, records: [] });
+    }
+    groupedRecords[groupedRecords.length - 1].records.push(record);
+  });
+
+  return (
+    <ScrollView
+      className="records-scroll"
+      scrollY
+      refresherEnabled
+      refresherTriggered={loading}
+      onRefresherRefresh={onRefresh}
+      onScrollToLower={onLoadMore}
+      lowerThreshold={100}
+    >
+      <View className="records-list">
+        {groupedRecords.map((group) => (
+          <View key={group.date} className="date-group">
+            <View className="date-header">
+              <Text className="date-text">
+                {formatDisplayDate(group.date)} {getWeekday(group.date)}
+              </Text>
+            </View>
+            <View className="date-records">
+              {group.records.map((record) => (
+                <RecordItem key={record._id} record={record} />
+              ))}
+            </View>
+          </View>
+        ))}
+      </View>
+      {loadingMore && (
+        <View className="loading-more">
+          <Text>加载中...</Text>
+        </View>
+      )}
+      {!hasMore && records.length > 0 && (
+        <View className="no-more">
+          <Text>没有更多了</Text>
+        </View>
+      )}
+    </ScrollView>
+  );
+}

--- a/src/pages/history/components/StoolChartView.tsx
+++ b/src/pages/history/components/StoolChartView.tsx
@@ -1,0 +1,92 @@
+import { View, Text } from "@tarojs/components";
+import { useState } from "react";
+import BarChart from "../../../components/BarChart";
+import type { ChartEvent } from "../../../types";
+
+interface StoolChartViewProps {
+  title: string;
+  data: { date: string; value: number }[];
+  maxValue?: number;
+  loading: boolean;
+  showHelp?: boolean;
+  events: ChartEvent[];
+  onEventTap: (event: ChartEvent) => void;
+  onAddEvent: () => void;
+  dateRangeSelector: React.ReactNode;
+}
+
+export default function StoolChartView({
+  title,
+  data,
+  maxValue,
+  loading,
+  showHelp,
+  events,
+  onEventTap,
+  onAddEvent,
+  dateRangeSelector,
+}: StoolChartViewProps) {
+  const [scoreHelpVisible, setScoreHelpVisible] = useState(false);
+
+  return (
+    <View className="stats-view">
+      <View className="stats-header">
+        <View className="stats-header-row">
+          <View className="stats-title-row">
+            <Text className="stats-title">{title}</Text>
+            {showHelp && (
+              <View className="stats-help-btn" onClick={() => setScoreHelpVisible(true)}>
+                <Text>?</Text>
+              </View>
+            )}
+          </View>
+          <View className="add-event-btn" onClick={onAddEvent}>
+            <Text>+ 事件</Text>
+          </View>
+        </View>
+        {dateRangeSelector}
+      </View>
+      <View className="stats-chart-container">
+        {loading ? (
+          <View className="stats-loading">
+            <Text>加载中...</Text>
+          </View>
+        ) : data.length === 0 ? (
+          <View className="stats-empty">
+            <Text>暂无数据</Text>
+          </View>
+        ) : (
+          <BarChart data={data} maxValue={maxValue} events={events} onEventTap={onEventTap} />
+        )}
+      </View>
+
+      {scoreHelpVisible && (
+        <View className="help-popup-mask" onClick={() => setScoreHelpVisible(false)}>
+          <View className="help-popup" onClick={(e) => e.stopPropagation()}>
+            <Text className="help-popup-title">排便得分计算规则</Text>
+            <View className="help-popup-section">
+              <Text className="help-popup-subtitle">Bristol 分型得分：</Text>
+              <Text className="help-popup-item">3-4型（正常）：6分</Text>
+              <Text className="help-popup-item">2型或5型：4分</Text>
+              <Text className="help-popup-item">1型或6型：2分</Text>
+              <Text className="help-popup-item">7型（水样）：0分</Text>
+            </View>
+            <View className="help-popup-section">
+              <Text className="help-popup-subtitle">次数得分：</Text>
+              <Text className="help-popup-item">
+                1-2次：4分；3次：3分；4次：2分；5次：1分；6+次：0分
+              </Text>
+            </View>
+            <View className="help-popup-section">
+              <Text className="help-popup-item">每日得分 = 平均分型得分 + 次数得分</Text>
+              <Text className="help-popup-item">得分越高越好，满分 10 分</Text>
+            </View>
+            <View className="help-popup-btn" onClick={() => setScoreHelpVisible(false)}>
+              <Text>知道了</Text>
+            </View>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, ScrollView } from "@tarojs/components";
+import { View, Text } from "@tarojs/components";
 import Taro, { useDidShow } from "@tarojs/taro";
 import { useState, useCallback, useRef, useEffect } from "react";
 import { symptomService } from "../../services/symptom";
@@ -9,14 +9,15 @@ import { labTestService } from "../../services/labtest";
 import { examService } from "../../services/exam";
 import { eventService } from "../../services/event";
 import { findStandardIndicator, StandardIndicator } from "../../services/labtest-standards";
-import { formatDisplayDate, getWeekday, formatDate } from "../../utils/date";
-import IndicatorPicker from "../../components/IndicatorPicker";
-import RecordItem, { AnyRecord } from "../../components/RecordItem";
+import { formatDate } from "../../utils/date";
+import { AnyRecord } from "../../components/RecordItem";
 import CalendarPopup from "../../components/CalendarPopup";
 import EventFormPopup from "../../components/EventFormPopup";
-import BarChart from "../../components/BarChart";
-import LineChart, { LineChartData } from "../../components/LineChart";
+import { LineChartData } from "../../components/LineChart";
 import { RecordType, RECORD_TYPE_OPTIONS, LabTestRecord, ChartEvent } from "../../types";
+import StoolChartView from "./components/StoolChartView";
+import LabtestChartView from "./components/LabtestChartView";
+import RecordsList from "./components/RecordsList";
 import "./index.css";
 
 // 默认指标：粪便钙卫蛋白
@@ -412,17 +413,6 @@ export default function History() {
     setEditingEvent(undefined);
   };
 
-  // 按日期分组记录
-  const groupedRecords: { date: string; records: AnyRecord[] }[] = [];
-  let currentDate = "";
-  records.forEach((record) => {
-    if (record.date !== currentDate) {
-      currentDate = record.date;
-      groupedRecords.push({ date: record.date, records: [] });
-    }
-    groupedRecords[groupedRecords.length - 1].records.push(record);
-  });
-
   const { startDate: effectiveStartDate, endDate: effectiveEndDate } = getEffectiveDateRange();
 
   const renderDateRangeSelector = () => (
@@ -449,168 +439,6 @@ export default function History() {
       )}
     </View>
   );
-
-  const [scoreHelpVisible, setScoreHelpVisible] = useState(false);
-
-  const renderChartView = (
-    title: string,
-    data: { date: string; value: number }[],
-    maxValue?: number,
-    showHelp?: boolean,
-  ) => (
-    <View className="stats-view">
-      <View className="stats-header">
-        <View className="stats-header-row">
-          <View className="stats-title-row">
-            <Text className="stats-title">{title}</Text>
-            {showHelp && (
-              <View className="stats-help-btn" onClick={() => setScoreHelpVisible(true)}>
-                <Text>?</Text>
-              </View>
-            )}
-          </View>
-          <View className="add-event-btn" onClick={handleAddEvent}>
-            <Text>+ 事件</Text>
-          </View>
-        </View>
-        {renderDateRangeSelector()}
-      </View>
-      <View className="stats-chart-container">
-        {statsLoading ? (
-          <View className="stats-loading">
-            <Text>加载中...</Text>
-          </View>
-        ) : data.length === 0 ? (
-          <View className="stats-empty">
-            <Text>暂无数据</Text>
-          </View>
-        ) : (
-          <BarChart data={data} maxValue={maxValue} events={events} onEventTap={handleEventTap} />
-        )}
-      </View>
-    </View>
-  );
-
-  const renderLabtestStatsView = () => {
-    const isOutOfRange = (value: number) => {
-      if (selectedIndicator.refMin !== undefined && value < selectedIndicator.refMin) return true;
-      if (selectedIndicator.refMax !== undefined && value > selectedIndicator.refMax) return true;
-      return false;
-    };
-
-    return (
-      <View className="stats-view">
-        <View className="stats-header">
-          <View className="stats-header-row">
-            <View
-              className="stats-title indicator-selector"
-              onClick={() => setIndicatorPickerVisible(true)}
-            >
-              <Text>
-                {selectedIndicator.nameZh} ({selectedIndicator.abbr})
-              </Text>
-              <Text className="indicator-selector-arrow">▼</Text>
-            </View>
-            <View className="add-event-btn" onClick={handleAddEvent}>
-              <Text>+ 事件</Text>
-            </View>
-          </View>
-          {renderDateRangeSelector()}
-        </View>
-        <View className="stats-chart-container">
-          {labtestStatsLoading ? (
-            <View className="stats-loading">
-              <Text>加载中...</Text>
-            </View>
-          ) : labtestChartData.length === 0 ? (
-            <View className="stats-empty">
-              <Text>暂无数据</Text>
-            </View>
-          ) : (
-            <LineChart
-              data={labtestChartData}
-              unit={selectedIndicator.unit}
-              refMin={selectedIndicator.refMin}
-              refMax={selectedIndicator.refMax}
-              events={events}
-              onEventTap={handleEventTap}
-            />
-          )}
-        </View>
-        {labtestChartData.length > 0 && (
-          <View className="stats-data-list">
-            {[...labtestChartData].reverse().map((item, index) => (
-              <View key={index} className="stats-data-item">
-                <Text className="stats-data-date">{item.date}</Text>
-                <Text
-                  className={`stats-data-value ${isOutOfRange(item.value) ? "out-of-range" : ""}`}
-                >
-                  {item.displayValue || item.value} {selectedIndicator.unit}
-                </Text>
-              </View>
-            ))}
-          </View>
-        )}
-
-        <IndicatorPicker
-          visible={indicatorPickerVisible}
-          onSelect={handleIndicatorSelect}
-          onClose={() => setIndicatorPickerVisible(false)}
-        />
-      </View>
-    );
-  };
-
-  const renderRecordsList = () => {
-    if (loading) {
-      return <View className="loading">加载中...</View>;
-    }
-    if (records.length === 0) {
-      return (
-        <View className="empty">
-          <Text className="empty-text">暂无记录</Text>
-        </View>
-      );
-    }
-    return (
-      <ScrollView
-        className="records-scroll"
-        scrollY
-        refresherEnabled
-        refresherTriggered={loading}
-        onRefresherRefresh={handleRefresh}
-        onScrollToLower={handleLoadMore}
-        lowerThreshold={100}
-      >
-        <View className="records-list">
-          {groupedRecords.map((group) => (
-            <View key={group.date} className="date-group">
-              <View className="date-header">
-                <Text className="date-text">
-                  {formatDisplayDate(group.date)} {getWeekday(group.date)}
-                </Text>
-              </View>
-              <View className="date-records">
-                {group.records.map((record) => (
-                  <RecordItem key={record._id} record={record} />
-                ))}
-              </View>
-            </View>
-          ))}
-        </View>
-        {loadingMore && (
-          <View className="loading-more">
-            <Text>加载中...</Text>
-          </View>
-        )}
-        {!hasMore && records.length > 0 && (
-          <View className="no-more">
-            <Text>没有更多了</Text>
-          </View>
-        )}
-      </ScrollView>
-    );
-  };
 
   return (
     <View className="history-page">
@@ -693,13 +521,52 @@ export default function History() {
         </View>
       )}
 
-      {selectedType === "stool" && stoolViewTab === "score"
-        ? renderChartView("每日排便得分", scoreData, 10, true)
-        : selectedType === "stool" && stoolViewTab === "count"
-          ? renderChartView("每日排便次数", countData)
-          : selectedType === "labtest" && labtestViewTab === "chart"
-            ? renderLabtestStatsView()
-            : renderRecordsList()}
+      {selectedType === "stool" && stoolViewTab === "score" ? (
+        <StoolChartView
+          title="每日排便得分"
+          data={scoreData}
+          maxValue={10}
+          loading={statsLoading}
+          showHelp
+          events={events}
+          onEventTap={handleEventTap}
+          onAddEvent={handleAddEvent}
+          dateRangeSelector={renderDateRangeSelector()}
+        />
+      ) : selectedType === "stool" && stoolViewTab === "count" ? (
+        <StoolChartView
+          title="每日排便次数"
+          data={countData}
+          loading={statsLoading}
+          events={events}
+          onEventTap={handleEventTap}
+          onAddEvent={handleAddEvent}
+          dateRangeSelector={renderDateRangeSelector()}
+        />
+      ) : selectedType === "labtest" && labtestViewTab === "chart" ? (
+        <LabtestChartView
+          chartData={labtestChartData}
+          loading={labtestStatsLoading}
+          selectedIndicator={selectedIndicator}
+          indicatorPickerVisible={indicatorPickerVisible}
+          events={events}
+          onIndicatorSelect={handleIndicatorSelect}
+          onIndicatorPickerOpen={() => setIndicatorPickerVisible(true)}
+          onIndicatorPickerClose={() => setIndicatorPickerVisible(false)}
+          onEventTap={handleEventTap}
+          onAddEvent={handleAddEvent}
+          dateRangeSelector={renderDateRangeSelector()}
+        />
+      ) : (
+        <RecordsList
+          records={records}
+          loading={loading}
+          loadingMore={loadingMore}
+          hasMore={hasMore}
+          onRefresh={handleRefresh}
+          onLoadMore={handleLoadMore}
+        />
+      )}
 
       <EventFormPopup
         visible={eventFormVisible}
@@ -707,34 +574,6 @@ export default function History() {
         onConfirm={handleEventFormConfirm}
         onClose={handleEventFormClose}
       />
-
-      {scoreHelpVisible && (
-        <View className="help-popup-mask" onClick={() => setScoreHelpVisible(false)}>
-          <View className="help-popup" onClick={(e) => e.stopPropagation()}>
-            <Text className="help-popup-title">排便得分计算规则</Text>
-            <View className="help-popup-section">
-              <Text className="help-popup-subtitle">Bristol 分型得分：</Text>
-              <Text className="help-popup-item">3-4型（正常）：6分</Text>
-              <Text className="help-popup-item">2型或5型：4分</Text>
-              <Text className="help-popup-item">1型或6型：2分</Text>
-              <Text className="help-popup-item">7型（水样）：0分</Text>
-            </View>
-            <View className="help-popup-section">
-              <Text className="help-popup-subtitle">次数得分：</Text>
-              <Text className="help-popup-item">
-                1-2次：4分；3次：3分；4次：2分；5次：1分；6+次：0分
-              </Text>
-            </View>
-            <View className="help-popup-section">
-              <Text className="help-popup-item">每日得分 = 平均分型得分 + 次数得分</Text>
-              <Text className="help-popup-item">得分越高越好，满分 10 分</Text>
-            </View>
-            <View className="help-popup-btn" onClick={() => setScoreHelpVisible(false)}>
-              <Text>知道了</Text>
-            </View>
-          </View>
-        </View>
-      )}
     </View>
   );
 }

--- a/src/pages/labtest/add/components/IndicatorEditModal.tsx
+++ b/src/pages/labtest/add/components/IndicatorEditModal.tsx
@@ -1,0 +1,63 @@
+import { View, Text, Input } from "@tarojs/components";
+
+interface EditingIndicator {
+  index: number | null;
+  name: string;
+  value: string;
+}
+
+interface IndicatorEditModalProps {
+  editing: EditingIndicator;
+  onNameChange: (name: string) => void;
+  onValueChange: (value: string) => void;
+  onSave: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export default function IndicatorEditModal({
+  editing,
+  onNameChange,
+  onValueChange,
+  onSave,
+  onDelete,
+  onClose,
+}: IndicatorEditModalProps) {
+  return (
+    <View className="indicator-modal-mask" onClick={onClose}>
+      <View className="indicator-modal" onClick={(e) => e.stopPropagation()}>
+        <Text className="indicator-modal-title">
+          {editing.index === null ? "添加指标" : "编辑指标"}
+        </Text>
+        <View className="indicator-modal-field">
+          <Text className="indicator-modal-label">指标名称</Text>
+          <Input
+            className="indicator-modal-input"
+            placeholder="如：白细胞计数"
+            value={editing.name}
+            onInput={(e) => onNameChange(e.detail.value)}
+          />
+        </View>
+        <View className="indicator-modal-field">
+          <Text className="indicator-modal-label">结果值</Text>
+          <Input
+            className="indicator-modal-input"
+            placeholder="如：5.2"
+            value={editing.value}
+            onInput={(e) => onValueChange(e.detail.value)}
+          />
+        </View>
+        <View className="indicator-modal-actions">
+          <View className="indicator-modal-btn primary" onClick={onSave}>
+            保存
+          </View>
+        </View>
+        {editing.index !== null && (
+          <View className="indicator-modal-delete" onClick={onDelete}>
+            删除此指标
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/src/pages/labtest/add/components/IndicatorTable.tsx
+++ b/src/pages/labtest/add/components/IndicatorTable.tsx
@@ -1,0 +1,99 @@
+import { View, Text } from "@tarojs/components";
+import type { LabTestIndicator } from "../../../../types";
+
+interface IndicatorTableProps {
+  indicators: LabTestIndicator[];
+  onEdit: (index: number) => void;
+}
+
+const getRefText = (ind: LabTestIndicator) =>
+  ind.refValue ||
+  (ind.refMin !== undefined && ind.refMax !== undefined
+    ? `${ind.refMin}-${ind.refMax}`
+    : ind.refMin !== undefined
+      ? `≥${ind.refMin}`
+      : ind.refMax !== undefined
+        ? `≤${ind.refMax}`
+        : "-");
+
+const isNegativeValue = (value: string) => {
+  const v = value.toLowerCase().trim();
+  return v === "negative" || v === "neg" || v === "阴性" || v === "(-)" || v === "-";
+};
+
+const isPositiveValue = (value: string) => {
+  const v = value.toLowerCase().trim();
+  return v === "positive" || v === "pos" || v === "阳性" || v === "(+)" || v === "+";
+};
+
+const getAbnormalFlag = (ind: LabTestIndicator) => {
+  // Qualitative: refValue=negative means negative is normal, positive is abnormal
+  if (ind.refValue === "negative") {
+    if (isNegativeValue(ind.value)) return "";
+    if (isPositiveValue(ind.value)) return "↑";
+  }
+
+  // Quantitative
+  const numValue = parseFloat(ind.value);
+  if (isNaN(numValue)) return "";
+  if (ind.refMin !== undefined && numValue < ind.refMin) return "↓";
+  if (ind.refMax !== undefined && numValue > ind.refMax) return "↑";
+  return "";
+};
+
+export default function IndicatorTable({ indicators, onEdit }: IndicatorTableProps) {
+  if (indicators.length === 0) {
+    return <Text className="no-indicators">点击"手动添加"或上传图片后"AI 识别"</Text>;
+  }
+
+  // Group by category
+  const groups = indicators.reduce(
+    (acc, ind, originalIndex) => {
+      const cat = ind.category || "其他";
+      if (!acc[cat]) acc[cat] = [];
+      acc[cat].push({ ...ind, originalIndex });
+      return acc;
+    },
+    {} as Record<string, (LabTestIndicator & { originalIndex: number })[]>,
+  );
+
+  return (
+    <View className="indicators-list">
+      {Object.entries(groups).map(([category, items]) => (
+        <View key={category} className="indicator-group">
+          <Text className="indicator-group-title">{category}</Text>
+          <View className="indicator-table">
+            <View className="indicator-table-header">
+              <Text className="indicator-col-name">指标</Text>
+              <Text className="indicator-col-value">结果</Text>
+              <Text className="indicator-col-ref">参考</Text>
+              <Text className="indicator-col-unit">单位</Text>
+            </View>
+            {items.map((ind) => {
+              const abnormalFlag = getAbnormalFlag(ind);
+              return (
+                <View
+                  key={ind.originalIndex}
+                  className="indicator-table-row clickable"
+                  onClick={() => onEdit(ind.originalIndex)}
+                >
+                  <Text className="indicator-col-name">{ind.name}</Text>
+                  <Text className="indicator-col-value">
+                    {ind.value}
+                    {abnormalFlag && (
+                      <Text className={`abnormal-flag ${abnormalFlag === "↑" ? "high" : "low"}`}>
+                        {abnormalFlag}
+                      </Text>
+                    )}
+                  </Text>
+                  <Text className="indicator-col-ref">{getRefText(ind)}</Text>
+                  <Text className="indicator-col-unit">{ind.unit || "-"}</Text>
+                </View>
+              );
+            })}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/src/pages/labtest/add/index.tsx
+++ b/src/pages/labtest/add/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Image, Input } from "@tarojs/components";
+import { View, Text, Image } from "@tarojs/components";
 import Taro, { useRouter } from "@tarojs/taro";
 import { useState, useEffect, useRef } from "react";
 import { labTestService } from "../../../services/labtest";
@@ -9,6 +9,8 @@ import { formatDate, formatTime } from "../../../utils/date";
 import { showError } from "../../../utils/error";
 import CalendarPopup from "../../../components/CalendarPopup";
 import TimePicker from "../../../components/TimePicker";
+import IndicatorTable from "./components/IndicatorTable";
+import IndicatorEditModal from "./components/IndicatorEditModal";
 import type { LabTestIndicator } from "../../../types";
 import "./index.css";
 
@@ -398,137 +400,19 @@ export default function LabTestAdd() {
             )}
           </View>
         </View>
-        {indicators.length > 0 ? (
-          <View className="indicators-list">
-            {(() => {
-              // 按类别分组
-              const groups = indicators.reduce(
-                (acc, ind, originalIndex) => {
-                  const cat = ind.category || "其他";
-                  if (!acc[cat]) acc[cat] = [];
-                  acc[cat].push({ ...ind, originalIndex });
-                  return acc;
-                },
-                {} as Record<string, ((typeof indicators)[0] & { originalIndex: number })[]>,
-              );
-
-              const getRefText = (ind: (typeof indicators)[0]) =>
-                ind.refValue ||
-                (ind.refMin !== undefined && ind.refMax !== undefined
-                  ? `${ind.refMin}-${ind.refMax}`
-                  : ind.refMin !== undefined
-                    ? `≥${ind.refMin}`
-                    : ind.refMax !== undefined
-                      ? `≤${ind.refMax}`
-                      : "-");
-
-              // 判断值是否超出参考范围
-              const isNegativeValue = (value: string) => {
-                const v = value.toLowerCase().trim();
-                return v === "negative" || v === "neg" || v === "阴性" || v === "(-)" || v === "-";
-              };
-
-              const isPositiveValue = (value: string) => {
-                const v = value.toLowerCase().trim();
-                return v === "positive" || v === "pos" || v === "阳性" || v === "(+)" || v === "+";
-              };
-
-              const getAbnormalFlag = (ind: (typeof indicators)[0]) => {
-                // 定性结果：refValue=negative 时，阴性正常，阳性异常
-                if (ind.refValue === "negative") {
-                  if (isNegativeValue(ind.value)) return "";
-                  if (isPositiveValue(ind.value)) return "↑";
-                }
-
-                // 定量结果
-                const numValue = parseFloat(ind.value);
-                if (isNaN(numValue)) return "";
-                if (ind.refMin !== undefined && numValue < ind.refMin) return "↓";
-                if (ind.refMax !== undefined && numValue > ind.refMax) return "↑";
-                return "";
-              };
-
-              return Object.entries(groups).map(([category, items]) => (
-                <View key={category} className="indicator-group">
-                  <Text className="indicator-group-title">{category}</Text>
-                  <View className="indicator-table">
-                    <View className="indicator-table-header">
-                      <Text className="indicator-col-name">指标</Text>
-                      <Text className="indicator-col-value">结果</Text>
-                      <Text className="indicator-col-ref">参考</Text>
-                      <Text className="indicator-col-unit">单位</Text>
-                    </View>
-                    {items.map((ind) => {
-                      const abnormalFlag = getAbnormalFlag(ind);
-                      return (
-                        <View
-                          key={ind.originalIndex}
-                          className="indicator-table-row clickable"
-                          onClick={() => handleEditIndicator(ind.originalIndex)}
-                        >
-                          <Text className="indicator-col-name">{ind.name}</Text>
-                          <Text className="indicator-col-value">
-                            {ind.value}
-                            {abnormalFlag && (
-                              <Text
-                                className={`abnormal-flag ${abnormalFlag === "↑" ? "high" : "low"}`}
-                              >
-                                {abnormalFlag}
-                              </Text>
-                            )}
-                          </Text>
-                          <Text className="indicator-col-ref">{getRefText(ind)}</Text>
-                          <Text className="indicator-col-unit">{ind.unit || "-"}</Text>
-                        </View>
-                      );
-                    })}
-                  </View>
-                </View>
-              ));
-            })()}
-          </View>
-        ) : (
-          <Text className="no-indicators">点击"手动添加"或上传图片后"AI 识别"</Text>
-        )}
+        <IndicatorTable indicators={indicators} onEdit={handleEditIndicator} />
       </View>
 
       {/* 编辑指标弹窗 */}
       {editingIndicator && (
-        <View className="indicator-modal-mask" onClick={() => setEditingIndicator(null)}>
-          <View className="indicator-modal" onClick={(e) => e.stopPropagation()}>
-            <Text className="indicator-modal-title">
-              {editingIndicator.index === null ? "添加指标" : "编辑指标"}
-            </Text>
-            <View className="indicator-modal-field">
-              <Text className="indicator-modal-label">指标名称</Text>
-              <Input
-                className="indicator-modal-input"
-                placeholder="如：白细胞计数"
-                value={editingIndicator.name}
-                onInput={(e) => setEditingIndicator({ ...editingIndicator, name: e.detail.value })}
-              />
-            </View>
-            <View className="indicator-modal-field">
-              <Text className="indicator-modal-label">结果值</Text>
-              <Input
-                className="indicator-modal-input"
-                placeholder="如：5.2"
-                value={editingIndicator.value}
-                onInput={(e) => setEditingIndicator({ ...editingIndicator, value: e.detail.value })}
-              />
-            </View>
-            <View className="indicator-modal-actions">
-              <View className="indicator-modal-btn primary" onClick={handleSaveIndicator}>
-                保存
-              </View>
-            </View>
-            {editingIndicator.index !== null && (
-              <View className="indicator-modal-delete" onClick={handleDeleteIndicator}>
-                删除此指标
-              </View>
-            )}
-          </View>
-        </View>
+        <IndicatorEditModal
+          editing={editingIndicator}
+          onNameChange={(name) => setEditingIndicator({ ...editingIndicator, name })}
+          onValueChange={(value) => setEditingIndicator({ ...editingIndicator, value })}
+          onSave={handleSaveIndicator}
+          onDelete={handleDeleteIndicator}
+          onClose={() => setEditingIndicator(null)}
+        />
       )}
 
       {/* 提交按钮 */}


### PR DESCRIPTION
## Summary
- Extract StoolChartView, LabtestChartView, RecordsList from history/index.tsx (740 → 579 lines)
- Extract IndicatorTable, IndicatorEditModal from labtest/add/index.tsx (547 → 431 lines)
- New components are page-specific, placed in `components/` subdirectories under each page

## Changes
| File | Before | After |
|------|--------|-------|
| history/index.tsx | 740 | 579 |
| labtest/add/index.tsx | 547 | 431 |

Note: history/index.tsx didn't reach the 300-400 line target because the remaining code is cohesive state/logic that would be artificial to split further. The render-heavy portions have been extracted.

Closes #183

## Test plan
- [ ] Verify history page renders correctly (stool charts, labtest charts, records list)
- [ ] Verify labtest add page works (indicator table, edit modal)
- [ ] Check build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)