### PR TITLE
feat(symptom): add weight field and rename to 身体状态

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Do not create local design/spec files (e.g., `docs/superpowers/specs/`). All des
 
 Always use `pnpm` instead of `npm` or `yarn`.
 
+## Build Verification
+
+Always run `pnpm build` after making code edits to verify compilation succeeds.
+
 ## Git Workflow
 
 Always create a pull request for changes. Never push directly to main.

--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -33,11 +33,6 @@
   color: #333;
   padding: 2px 8px;
   border-radius: 4px;
-  flex: 1;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
 }
 
 .record-desc {

--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -24,6 +24,8 @@
 .record-feeling {
   font-size: 28px;
   margin-right: 8px;
+  display: flex;
+  align-items: center;
 }
 
 .record-symptoms {

--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -23,9 +23,9 @@
 
 .record-feeling {
   font-size: 28px;
-  margin-right: 8px;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .record-symptoms {
@@ -33,6 +33,11 @@
   color: #333;
   padding: 2px 8px;
   border-radius: 4px;
+  flex: 1;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }
 
 .record-desc {

--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -1,6 +1,6 @@
 .record-item {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   padding: 20px 24px;
   gap: 16px;
   border-bottom: 1px solid #f5f5f5;

--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -26,11 +26,11 @@
   margin-right: 8px;
 }
 
-.record-severity {
-  font-size: 22px;
-  color: #fff;
+.record-symptoms {
+  font-size: 28px;
+  color: #333;
   padding: 4px 12px;
-  border-radius: 4px;
+  border-radius: 6px;
 }
 
 .record-desc {

--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -29,8 +29,8 @@
 .record-symptoms {
   font-size: 28px;
   color: #333;
-  padding: 4px 12px;
-  border-radius: 6px;
+  padding: 2px 8px;
+  border-radius: 4px;
 }
 
 .record-desc {

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -78,7 +78,9 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
         const severity = getSeverityInfo(record.severity);
         return (
           <>
-            <Text className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</Text>
+            {record.overallFeeling && (
+              <Text className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</Text>
+            )}
             {severity && (
               <Text className="record-severity" style={{ backgroundColor: severity.color }}>
                 {severity.label}
@@ -87,6 +89,7 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
             {record.symptoms.length > 0 && (
               <Text className="record-desc">{record.symptoms.join("、")}</Text>
             )}
+            {record.weight && <Text className="record-desc">{record.weight}kg</Text>}
           </>
         );
       }

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -79,7 +79,7 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
         return (
           <>
             {record.overallFeeling && (
-              <Text className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</Text>
+              <View className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</View>
             )}
             {record.symptoms.length > 0 && (
               <Text

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -81,13 +81,13 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
             {record.overallFeeling && (
               <Text className="record-feeling">{getFeelingEmoji(record.overallFeeling)}</Text>
             )}
-            {severity && (
-              <Text className="record-severity" style={{ backgroundColor: severity.color }}>
-                {severity.label}
-              </Text>
-            )}
             {record.symptoms.length > 0 && (
-              <Text className="record-desc">{record.symptoms.join("、")}</Text>
+              <Text
+                className="record-symptoms"
+                style={severity ? { backgroundColor: `${severity.color}20` } : undefined}
+              >
+                {record.symptoms.join("、")}
+              </Text>
             )}
             {record.weight && <Text className="record-desc">{record.weight}kg</Text>}
           </>

--- a/src/pages/symptom/add/index.css
+++ b/src/pages/symptom/add/index.css
@@ -95,6 +95,14 @@
 }
 
 /* 严重程度 */
+.section-subtitle {
+  display: block;
+  font-size: 26px;
+  color: #666;
+  margin-top: 24px;
+  margin-bottom: 16px;
+}
+
 .severity-options {
   display: flex;
   gap: 16px;

--- a/src/pages/symptom/add/index.css
+++ b/src/pages/symptom/add/index.css
@@ -95,15 +95,8 @@
 }
 
 /* 严重程度 */
-.section-subtitle {
-  display: block;
-  font-size: 26px;
-  color: #666;
-  margin-top: 24px;
-  margin-bottom: 16px;
-}
-
 .severity-options {
+  margin-top: 20px;
   display: flex;
   gap: 16px;
 }

--- a/src/pages/symptom/add/index.css
+++ b/src/pages/symptom/add/index.css
@@ -122,3 +122,25 @@
   font-size: 28px;
   color: #333;
 }
+
+/* 体重输入 */
+.weight-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.weight-input {
+  flex: 1;
+  height: 80px;
+  padding: 0 20px;
+  border: 2px solid #f0f0f0;
+  border-radius: 8px;
+  font-size: 32px;
+  box-sizing: border-box;
+}
+
+.weight-unit {
+  font-size: 28px;
+  color: #666;
+}

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -260,30 +260,30 @@ export default function SymptomAdd() {
             添加
           </View>
         </View>
+        {/* 严重程度 - 仅在选择了症状后显示 */}
+        {symptoms.length > 0 && (
+          <>
+            <Text className="section-subtitle">严重程度</Text>
+            <View className="severity-options">
+              {SEVERITY_OPTIONS.map((option) => (
+                <View
+                  key={option.value}
+                  className={`severity-item ${severity === option.value ? "active" : ""}`}
+                  style={{
+                    borderColor: severity === option.value ? option.color : "#f0f0f0",
+                    backgroundColor:
+                      severity === option.value ? `${option.color}15` : "transparent",
+                  }}
+                  onClick={() => setSeverity(option.value as SymptomRecord["severity"])}
+                >
+                  <View className="severity-dot" style={{ backgroundColor: option.color }} />
+                  <Text className="severity-label">{option.label}</Text>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
       </View>
-
-      {/* 严重程度 */}
-      {symptoms.length > 0 && (
-        <View className="section">
-          <Text className="section-title">严重程度</Text>
-          <View className="severity-options">
-            {SEVERITY_OPTIONS.map((option) => (
-              <View
-                key={option.value}
-                className={`severity-item ${severity === option.value ? "active" : ""}`}
-                style={{
-                  borderColor: severity === option.value ? option.color : "#f0f0f0",
-                  backgroundColor: severity === option.value ? `${option.color}15` : "transparent",
-                }}
-                onClick={() => setSeverity(option.value as SymptomRecord["severity"])}
-              >
-                <View className="severity-dot" style={{ backgroundColor: option.color }} />
-                <Text className="severity-label">{option.label}</Text>
-              </View>
-            ))}
-          </View>
-        </View>
-      )}
 
       {/* 体重 */}
       <View className="section">

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -44,7 +44,7 @@ export default function SymptomAdd() {
   const [customSymptom, setCustomSymptom] = useState("");
   const [savedCustomSymptoms, setSavedCustomSymptoms] = useState<string[]>([]);
   const [severity, setSeverity] = useState<SymptomRecord["severity"]>(undefined);
-  const [overallFeeling, setOverallFeeling] = useState<1 | 2 | 3 | 4 | 5>(3);
+  const [overallFeeling, setOverallFeeling] = useState<1 | 2 | 3 | 4 | 5 | undefined>(undefined);
   const [weight, setWeight] = useState("");
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -65,7 +65,7 @@ export default function SymptomAdd() {
         setTime(record.time || formatTime());
         setSymptoms(record.symptoms);
         setSeverity(record.severity);
-        setOverallFeeling(record.overallFeeling);
+        setOverallFeeling(record.overallFeeling ?? undefined);
         setWeight(record.weight !== undefined ? String(record.weight) : "");
         setNote(record.note || "");
       }
@@ -215,7 +215,7 @@ export default function SymptomAdd() {
             <View
               key={option.value}
               className={`feeling-item ${overallFeeling === option.value ? "active" : ""}`}
-              onClick={() => setOverallFeeling(option.value as typeof overallFeeling)}
+              onClick={() => setOverallFeeling(option.value as 1 | 2 | 3 | 4 | 5)}
             >
               <Text className="feeling-emoji">{option.emoji}</Text>
               <Text className="feeling-label">{option.label}</Text>

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -45,6 +45,7 @@ export default function SymptomAdd() {
   const [savedCustomSymptoms, setSavedCustomSymptoms] = useState<string[]>([]);
   const [severity, setSeverity] = useState<SymptomRecord["severity"]>(undefined);
   const [overallFeeling, setOverallFeeling] = useState<1 | 2 | 3 | 4 | 5>(3);
+  const [weight, setWeight] = useState("");
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [loading, setLoading] = useState(isEdit);
@@ -65,6 +66,7 @@ export default function SymptomAdd() {
         setSymptoms(record.symptoms);
         setSeverity(record.severity);
         setOverallFeeling(record.overallFeeling);
+        setWeight(record.weight !== undefined ? String(record.weight) : "");
         setNote(record.note || "");
       }
     } catch (error) {
@@ -148,12 +150,14 @@ export default function SymptomAdd() {
 
     setSubmitting(true);
     try {
+      const parsedWeight = weight.trim() ? parseFloat(weight) : undefined;
       const data = {
         date,
         time,
         symptoms,
         severity: symptoms.length > 0 ? severity : undefined,
         overallFeeling,
+        weight: parsedWeight && !isNaN(parsedWeight) ? parsedWeight : undefined,
         note: note.trim() || undefined,
       };
 
@@ -280,6 +284,21 @@ export default function SymptomAdd() {
           </View>
         </View>
       )}
+
+      {/* 体重 */}
+      <View className="section">
+        <Text className="section-title">体重（可选）</Text>
+        <View className="weight-row">
+          <Input
+            className="weight-input"
+            type="digit"
+            placeholder="输入体重"
+            value={weight}
+            onInput={(e) => setWeight(e.detail.value)}
+          />
+          <Text className="weight-unit">kg</Text>
+        </View>
+      </View>
 
       {/* 备注 */}
       <View className="section">

--- a/src/pages/symptom/add/index.tsx
+++ b/src/pages/symptom/add/index.tsx
@@ -262,26 +262,22 @@ export default function SymptomAdd() {
         </View>
         {/* 严重程度 - 仅在选择了症状后显示 */}
         {symptoms.length > 0 && (
-          <>
-            <Text className="section-subtitle">严重程度</Text>
-            <View className="severity-options">
-              {SEVERITY_OPTIONS.map((option) => (
-                <View
-                  key={option.value}
-                  className={`severity-item ${severity === option.value ? "active" : ""}`}
-                  style={{
-                    borderColor: severity === option.value ? option.color : "#f0f0f0",
-                    backgroundColor:
-                      severity === option.value ? `${option.color}15` : "transparent",
-                  }}
-                  onClick={() => setSeverity(option.value as SymptomRecord["severity"])}
-                >
-                  <View className="severity-dot" style={{ backgroundColor: option.color }} />
-                  <Text className="severity-label">{option.label}</Text>
-                </View>
-              ))}
-            </View>
-          </>
+          <View className="severity-options">
+            {SEVERITY_OPTIONS.map((option) => (
+              <View
+                key={option.value}
+                className={`severity-item ${severity === option.value ? "active" : ""}`}
+                style={{
+                  borderColor: severity === option.value ? option.color : "#f0f0f0",
+                  backgroundColor: severity === option.value ? `${option.color}15` : "transparent",
+                }}
+                onClick={() => setSeverity(option.value as SymptomRecord["severity"])}
+              >
+                <View className="severity-dot" style={{ backgroundColor: option.color }} />
+                <Text className="severity-label">{option.label}</Text>
+              </View>
+            ))}
+          </View>
         )}
       </View>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,7 +40,7 @@ export interface BaseRecord {
 export interface SymptomRecord extends BaseRecord {
   symptoms: string[]; // 症状列表
   severity?: 1 | 2 | 3; // 整体严重程度：轻度、中度、重度
-  overallFeeling: 1 | 2 | 3 | 4 | 5; // 整体感受 1很差 - 5很好
+  overallFeeling?: 1 | 2 | 3 | 4 | 5; // 整体感受 1很差 - 5很好
   weight?: number; // 体重（kg），支持一位小数
   note?: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export interface RecordTypeOption {
 }
 
 export const RECORD_TYPE_OPTIONS: RecordTypeOption[] = [
-  { value: "symptom", label: "体感", icon: "🌱", addPath: "/pages/symptom/add/index" },
+  { value: "symptom", label: "身体状态", icon: "🌱", addPath: "/pages/symptom/add/index" },
   { value: "medication", label: "用药", icon: "💊", addPath: "/pages/medication/add/index" },
   { value: "meal", label: "饮食", icon: "🍱", addPath: "/pages/meal/add/index" },
   { value: "stool", label: "排便", icon: "💩", addPath: "/pages/stool/add/index" },
@@ -36,11 +36,12 @@ export interface BaseRecord {
   deletedAt?: Date;
 }
 
-// 症状记录
+// 状态记录（原症状记录）
 export interface SymptomRecord extends BaseRecord {
   symptoms: string[]; // 症状列表
   severity?: 1 | 2 | 3; // 整体严重程度：轻度、中度、重度
   overallFeeling: 1 | 2 | 3 | 4 | 5; // 整体感受 1很差 - 5很好
+  weight?: number; // 体重（kg），支持一位小数
   note?: string;
 }
 


### PR DESCRIPTION
## Summary
- Rename label from "体感" to "身体状态"
- Add optional `weight` field to `SymptomRecord` (supports decimal, unit: kg)
- Add weight input to symptom form

Note: Stats page weight trend chart will be in a separate issue.

Closes #195

## Test plan
- [ ] Verify "身体状态" label appears in homepage and stats page
- [ ] Test adding a record with weight
- [ ] Test editing an existing record with weight
- [ ] Verify weight is optional (can save without it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)