### PR TITLE
feat(stats): 身体状态页面增加体重趋势图

### DIFF
--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -17,6 +17,7 @@ interface LineChartProps {
   refMax?: number;
   events?: ChartEvent[];
   onEventTap?: (event: ChartEvent) => void;
+  startFromZero?: boolean; // Default true for backward compatibility
 }
 
 export default function LineChart({
@@ -26,6 +27,7 @@ export default function LineChart({
   refMax,
   events = [],
   onEventTap,
+  startFromZero = true,
 }: LineChartProps) {
   const canvasId = useRef(`line-chart-${Date.now()}`).current;
   const eventPositionsRef = useRef<{ event: ChartEvent; x: number }[]>([]);
@@ -67,10 +69,20 @@ export default function LineChart({
         canvas.height = height * dpr;
         ctx.scale(dpr, dpr);
 
-        const positions = drawChart(ctx, width, height, data, unit, refMin, refMax, events);
+        const positions = drawChart(
+          ctx,
+          width,
+          height,
+          data,
+          unit,
+          refMin,
+          refMax,
+          events,
+          startFromZero,
+        );
         eventPositionsRef.current = positions;
       });
-  }, [data, unit, refMin, refMax, canvasId, events]);
+  }, [data, unit, refMin, refMax, canvasId, events, startFromZero]);
 
   return (
     <Canvas type="2d" id={canvasId} className="line-chart-canvas" onTouchEnd={handleTouchEnd} />
@@ -86,6 +98,7 @@ function drawChart(
   refMin?: number,
   refMax?: number,
   events: ChartEvent[] = [],
+  startFromZero = true,
 ): { event: ChartEvent; x: number }[] {
   const padding = { top: 30, right: 16, bottom: 50, left: 50 };
   const chartWidth = width - padding.left - padding.right;
@@ -105,8 +118,8 @@ function drawChart(
   if (refMin !== undefined) minValue = Math.min(minValue, refMin);
   if (refMax !== undefined) maxValue = Math.max(maxValue, refMax);
 
-  // Start from 0 unless there are negative values
-  if (minValue >= 0) {
+  // Start from 0 unless there are negative values or startFromZero is false
+  if (startFromZero && minValue >= 0) {
     minValue = 0;
   }
 

--- a/src/pages/stats/components/WeightChartView.tsx
+++ b/src/pages/stats/components/WeightChartView.tsx
@@ -1,0 +1,66 @@
+import { View, Text } from "@tarojs/components";
+import LineChart, { LineChartData } from "../../../components/LineChart";
+import type { ChartEvent } from "../../../types";
+
+interface WeightChartViewProps {
+  chartData: LineChartData[];
+  loading: boolean;
+  events: ChartEvent[];
+  onEventTap: (event: ChartEvent) => void;
+  onAddEvent: () => void;
+  dateRangeSelector: React.ReactNode;
+}
+
+export default function WeightChartView({
+  chartData,
+  loading,
+  events,
+  onEventTap,
+  onAddEvent,
+  dateRangeSelector,
+}: WeightChartViewProps) {
+  return (
+    <View className="stats-view">
+      <View className="stats-header">
+        <View className="stats-header-row">
+          <View className="stats-title">
+            <Text>体重趋势</Text>
+          </View>
+          <View className="add-event-btn" onClick={onAddEvent}>
+            <Text>+ 事件</Text>
+          </View>
+        </View>
+        {dateRangeSelector}
+      </View>
+      <View className="stats-chart-container">
+        {loading ? (
+          <View className="stats-loading">
+            <Text>加载中...</Text>
+          </View>
+        ) : chartData.length === 0 ? (
+          <View className="stats-empty">
+            <Text>暂无数据</Text>
+          </View>
+        ) : (
+          <LineChart
+            data={chartData}
+            unit="kg"
+            events={events}
+            onEventTap={onEventTap}
+            startFromZero={false}
+          />
+        )}
+      </View>
+      {chartData.length > 0 && (
+        <View className="stats-data-list">
+          {[...chartData].reverse().map((item, index) => (
+            <View key={index} className="stats-data-item">
+              <Text className="stats-data-date">{item.date}</Text>
+              <Text className="stats-data-value">{item.value} kg</Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -14,9 +14,16 @@ import { AnyRecord } from "../../components/RecordItem";
 import CalendarPopup from "../../components/CalendarPopup";
 import EventFormPopup from "../../components/EventFormPopup";
 import { LineChartData } from "../../components/LineChart";
-import { RecordType, RECORD_TYPE_OPTIONS, LabTestRecord, ChartEvent } from "../../types";
+import {
+  RecordType,
+  RECORD_TYPE_OPTIONS,
+  LabTestRecord,
+  SymptomRecord,
+  ChartEvent,
+} from "../../types";
 import StoolChartView from "./components/StoolChartView";
 import LabtestChartView from "./components/LabtestChartView";
+import WeightChartView from "./components/WeightChartView";
 import RecordsList from "./components/RecordsList";
 import "./index.css";
 
@@ -32,6 +39,7 @@ const DEFAULT_INDICATOR: StandardIndicator = {
 
 type StoolViewTab = "score" | "count" | "records";
 type LabtestViewTab = "chart" | "records";
+type SymptomViewTab = "weight" | "records";
 type DateRangePreset = "30" | "90" | "365" | "1095" | "all" | "custom";
 
 const PAGE_SIZE = 50;
@@ -76,6 +84,7 @@ export default function Stats() {
   // Stats view state
   const [stoolViewTab, setStoolViewTab] = useState<StoolViewTab>("score");
   const [labtestViewTab, setLabtestViewTab] = useState<LabtestViewTab>("chart");
+  const [symptomViewTab, setSymptomViewTab] = useState<SymptomViewTab>("weight");
   const [dateRangePreset, setDateRangePreset] = useState<DateRangePreset>(() => {
     const saved = Taro.getStorageSync("history_date_range_preset");
     // Migrate old "7" preset to "30"
@@ -93,6 +102,10 @@ export default function Stats() {
   // Labtest stats state
   const [labtestChartData, setLabtestChartData] = useState<LineChartData[]>([]);
   const [labtestStatsLoading, setLabtestStatsLoading] = useState(false);
+
+  // Weight stats state
+  const [weightChartData, setWeightChartData] = useState<LineChartData[]>([]);
+  const [weightStatsLoading, setWeightStatsLoading] = useState(false);
   const [selectedIndicator, setSelectedIndicator] = useState<StandardIndicator>(() => {
     const saved = Taro.getStorageSync("history_selected_indicator");
     return saved ? JSON.parse(saved) : DEFAULT_INDICATOR;
@@ -237,6 +250,26 @@ export default function Stats() {
     [],
   );
 
+  const loadWeightStatsData = useCallback(async (startDate: string, endDate: string) => {
+    setWeightStatsLoading(true);
+    try {
+      const allRecords = await symptomService.getByDateRange(startDate, endDate);
+      const chartData: LineChartData[] = [];
+      (allRecords as SymptomRecord[]).forEach((record) => {
+        if (record.weight !== undefined) {
+          chartData.push({ date: record.date, value: record.weight });
+        }
+      });
+      chartData.sort((a, b) => a.date.localeCompare(b.date));
+      setWeightChartData(chartData);
+    } catch (error) {
+      console.error("加载体重统计数据失败:", error);
+      Taro.showToast({ title: "加载失败", icon: "none" });
+    } finally {
+      setWeightStatsLoading(false);
+    }
+  }, []);
+
   const needsRefreshRef = useRef(true);
 
   useEffect(() => {
@@ -262,11 +295,13 @@ export default function Stats() {
 
     const { startDate, endDate } = getEffectiveDateRange();
     loadInitial(selectedType, startDate, endDate);
-    // Load chart data for stool and labtest
+    // Load chart data for stool, labtest, and symptom
     if (selectedType === "stool") {
       loadStatsData(startDate, endDate);
     } else if (selectedType === "labtest") {
       loadLabtestStatsData(startDate, endDate, selectedIndicator);
+    } else if (selectedType === "symptom") {
+      loadWeightStatsData(startDate, endDate);
     }
   });
 
@@ -283,15 +318,19 @@ export default function Stats() {
     setRecords([]);
     setStoolViewTab("score");
     setLabtestViewTab("chart");
-    // Reset labtest stats when switching types
+    setSymptomViewTab("weight");
+    // Reset stats when switching types
     setLabtestChartData([]);
+    setWeightChartData([]);
     const { startDate, endDate } = getEffectiveDateRange();
     loadInitial(type, startDate, endDate);
-    // Load chart data for stool and labtest
+    // Load chart data for stool, labtest, and symptom
     if (type === "stool") {
       loadStatsData(startDate, endDate);
     } else if (type === "labtest") {
       loadLabtestStatsData(startDate, endDate, selectedIndicator);
+    } else if (type === "symptom") {
+      loadWeightStatsData(startDate, endDate);
     }
   };
 
@@ -310,6 +349,15 @@ export default function Stats() {
     if (tab === "chart" && labtestChartData.length === 0) {
       const { startDate, endDate } = getEffectiveDateRange();
       loadLabtestStatsData(startDate, endDate, selectedIndicator);
+    }
+  };
+
+  const handleSymptomViewTabChange = (tab: SymptomViewTab) => {
+    if (tab === symptomViewTab) return;
+    setSymptomViewTab(tab);
+    if (tab === "weight" && weightChartData.length === 0) {
+      const { startDate, endDate } = getEffectiveDateRange();
+      loadWeightStatsData(startDate, endDate);
     }
   };
 
@@ -343,6 +391,9 @@ export default function Stats() {
       if (selectedType === "labtest" && labtestViewTab === "chart") {
         loadLabtestStatsData(startDate, endDate, selectedIndicator);
       }
+      if (selectedType === "symptom" && symptomViewTab === "weight") {
+        loadWeightStatsData(startDate, endDate);
+      }
     }
   };
 
@@ -364,6 +415,9 @@ export default function Stats() {
     }
     if (selectedType === "labtest" && labtestViewTab === "chart") {
       loadLabtestStatsData(start, end, selectedIndicator);
+    }
+    if (selectedType === "symptom" && symptomViewTab === "weight") {
+      loadWeightStatsData(start, end);
     }
   };
 
@@ -521,6 +575,23 @@ export default function Stats() {
         </View>
       )}
 
+      {selectedType === "symptom" && (
+        <View className="view-mode-tabs">
+          <View
+            className={`view-mode-tab ${symptomViewTab === "weight" ? "active" : ""}`}
+            onClick={() => handleSymptomViewTabChange("weight")}
+          >
+            <Text>体重趋势</Text>
+          </View>
+          <View
+            className={`view-mode-tab ${symptomViewTab === "records" ? "active" : ""}`}
+            onClick={() => handleSymptomViewTabChange("records")}
+          >
+            <Text>原始数据</Text>
+          </View>
+        </View>
+      )}
+
       {selectedType === "stool" && stoolViewTab === "score" ? (
         <StoolChartView
           title="每日排便得分"
@@ -553,6 +624,15 @@ export default function Stats() {
           onIndicatorSelect={handleIndicatorSelect}
           onIndicatorPickerOpen={() => setIndicatorPickerVisible(true)}
           onIndicatorPickerClose={() => setIndicatorPickerVisible(false)}
+          onEventTap={handleEventTap}
+          onAddEvent={handleAddEvent}
+          dateRangeSelector={renderDateRangeSelector()}
+        />
+      ) : selectedType === "symptom" && symptomViewTab === "weight" ? (
+        <WeightChartView
+          chartData={weightChartData}
+          loading={weightStatsLoading}
+          events={events}
           onEventTap={handleEventTap}
           onAddEvent={handleAddEvent}
           dateRangeSelector={renderDateRangeSelector()}


### PR DESCRIPTION
## Summary
- Add weight trend view tab under 身体状态 (symptom) type in stats page
- Reuse LineChart component with new `startFromZero` option for proper Y-axis scaling
- Support event annotations on weight chart (same as stool/labtest charts)

Closes #199

## Test plan
- [ ] Navigate to stats page and select 身体状态 (🌱) type
- [ ] Verify "体重趋势" and "原始数据" tabs appear
- [ ] Add symptom records with weight data
- [ ] Verify weight trend chart displays correctly with Y-axis not starting from zero
- [ ] Verify event annotations work on weight chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)