### PR TITLE
fix(stats): 修复身体状态页面切换日期范围后数据不更新

### DIFF
--- a/src/pages/stats/components/SymptomTrendChartView.tsx
+++ b/src/pages/stats/components/SymptomTrendChartView.tsx
@@ -77,16 +77,19 @@ export default function SymptomTrendChartView({
           />
         )}
       </View>
-      {chartData.length > 0 && (
+      {chartData.some((item) => item.value > 0) && (
         <View className="stats-data-list">
-          {[...chartData].reverse().map((item, index) => (
-            <View key={index} className="stats-data-item">
-              <Text className="stats-data-date">{item.date}</Text>
-              <Text className="stats-data-value">
-                {item.value === 1 ? "轻度" : item.value === 2 ? "中度" : "重度"}
-              </Text>
-            </View>
-          ))}
+          {[...chartData]
+            .filter((item) => item.value > 0)
+            .reverse()
+            .map((item, index) => (
+              <View key={index} className="stats-data-item">
+                <Text className="stats-data-date">{item.date}</Text>
+                <Text className="stats-data-value">
+                  {item.value <= 1 ? "轻度" : item.value <= 2 ? "中度" : "重度"}
+                </Text>
+              </View>
+            ))}
         </View>
       )}
 

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -7,6 +7,7 @@ import { stoolService } from "../../services/stool";
 import { medicationService } from "../../services/medication";
 import { labTestService } from "../../services/labtest";
 import { examService } from "../../services/exam";
+import { assessmentService } from "../../services/assessment";
 import { eventService } from "../../services/event";
 import { findStandardIndicator, StandardIndicator } from "../../services/labtest-standards";
 import { formatDate } from "../../utils/date";
@@ -47,6 +48,7 @@ const services = {
   stool: stoolService,
   labtest: labTestService,
   exam: examService,
+  assessment: assessmentService,
 } as const;
 
 function getDateDaysAgo(days: number): string {

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -465,6 +465,10 @@ export default function Stats() {
         loadLabtestStatsData(startDate, endDate, selectedIndicator);
       }
       if (selectedType === "symptom") {
+        // Clear non-active tabs so they reload when switched to
+        setFeelingData([]);
+        setWeightChartData([]);
+        setSymptomTrendData([]);
         if (symptomViewTab === "feeling") {
           loadFeelingStatsData(startDate, endDate);
         } else if (symptomViewTab === "weight") {
@@ -496,6 +500,10 @@ export default function Stats() {
       loadLabtestStatsData(start, end, selectedIndicator);
     }
     if (selectedType === "symptom") {
+      // Clear non-active tabs so they reload when switched to
+      setFeelingData([]);
+      setWeightChartData([]);
+      setSymptomTrendData([]);
       if (symptomViewTab === "feeling") {
         loadFeelingStatsData(start, end);
       } else if (symptomViewTab === "weight") {


### PR DESCRIPTION
## Summary
- 切换日期范围时，清空非当前 tab 的数据（整体感受/体重/症状）
- 确保切换回其他 tab 时会用新的日期范围重新加载数据

## Test plan
- [ ] 进入数据页面，选择身体状态
- [ ] 切换到体重趋势 tab，查看数据
- [ ] 切换日期范围（如从90天改为30天）
- [ ] 切换回体重趋势 tab，确认数据已按新日期范围更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)