### PR TITLE
feat(meal): 饮食进食量扩展为5个级别

### DIFF
--- a/src/components/AmountIcon/index.tsx
+++ b/src/components/AmountIcon/index.tsx
@@ -1,18 +1,32 @@
 import { Image } from "@tarojs/components";
 
-function generateAmountSvg(level: 1 | 2 | 3): string {
-  const filled = "#5FCF9A";
-  const empty = "#E5E5E5";
-  const colors = [
-    level >= 1 ? filled : empty,
-    level >= 2 ? filled : empty,
-    level >= 3 ? filled : empty,
-  ];
+function generateAmountSvg(level: 0 | 1 | 2 | 3 | 4): string {
+  const bucketColor = "#999";
+  const filledColor = "#5FCF9A";
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 12">
-    <rect x="0" y="0" width="10" height="12" rx="2" fill="${colors[0]}"/>
-    <rect x="13" y="0" width="10" height="12" rx="2" fill="${colors[1]}"/>
-    <rect x="26" y="0" width="10" height="12" rx="2" fill="${colors[2]}"/>
+  // Bucket shape: top width 20 (x: 2-22), bottom width 16 (x: 4-20)
+  // Height from y=4 to y=18 (14 units)
+  const numBars = level + 1;
+  const bars = [];
+  for (let i = 0; i < numBars; i++) {
+    const y = 15.5 - i * 2.6;
+    // Calculate width at this y position (linear interpolation)
+    // At y=18 (bottom): left=4, right=20, width=16
+    // At y=4 (top): left=2, right=22, width=20
+    const t = (18 - y) / 14; // 0 at bottom, 1 at top
+    const left = 4 - t * 2 + 1; // +1 for padding
+    const right = 20 + t * 2 - 1; // -1 for padding
+    const width = right - left;
+    bars.push(
+      `<rect x="${left}" y="${y}" width="${width}" height="2" rx="1" fill="${filledColor}"/>`,
+    );
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 20">
+    <!-- Bucket outline (slightly wider at top) -->
+    <path d="M2 4 L4 18 L20 18 L22 4" fill="none" stroke="${bucketColor}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Food bars -->
+    ${bars.join("")}
   </svg>`;
 }
 
@@ -22,12 +36,12 @@ function svgToDataUri(svg: string): string {
 }
 
 interface AmountIconProps {
-  level: 1 | 2 | 3;
+  level: 0 | 1 | 2 | 3 | 4;
   size?: number;
 }
 
-export default function AmountIcon({ level, size = 36 }: AmountIconProps) {
-  const height = size / 3;
+export default function AmountIcon({ level, size = 24 }: AmountIconProps) {
+  const height = (size / 24) * 20;
   return (
     <Image
       src={svgToDataUri(generateAmountSvg(level))}

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -114,7 +114,7 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
         return (
           <>
             <View className="record-feeling">
-              <AmountIcon level={record.amount as 1 | 2 | 3} size={24} />
+              <AmountIcon level={record.amount as 0 | 1 | 2 | 3 | 4} size={24} />
             </View>
             <Text className="record-desc">{record.foods.join("、")}</Text>
           </>

--- a/src/constants/meal.ts
+++ b/src/constants/meal.ts
@@ -99,7 +99,9 @@ export const FOOD_CATEGORIES = [
 
 // 进食量选项
 export const AMOUNT_OPTIONS = [
-  { value: 1, label: "少量" },
+  { value: 0, label: "少量" },
+  { value: 1, label: "较少" },
   { value: 2, label: "适中" },
-  { value: 3, label: "大量" },
+  { value: 3, label: "较多" },
+  { value: 4, label: "大量" },
 ] as const;

--- a/src/pages/meal/add/index.tsx
+++ b/src/pages/meal/add/index.tsx
@@ -53,7 +53,7 @@ export default function MealAdd() {
   const [selectedCategory, setSelectedCategory] = useState(-1); // -1 = 我的常用
   const [selectedFoods, setSelectedFoods] = useState<string[]>([]);
   const [manualInput, setManualInput] = useState("");
-  const [amount, setAmount] = useState<1 | 2 | 3>(2);
+  const [amount, setAmount] = useState<0 | 1 | 2 | 3 | 4>(2);
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [customFoods, setCustomFoods] = useState<string[]>([]);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,7 +68,7 @@ export interface SymptomRecord extends BaseRecord {
 // 饮食记录
 export interface MealRecord extends BaseRecord {
   foods: string[];
-  amount: 1 | 2 | 3; // 1-少量 2-适中 3-大量
+  amount: 0 | 1 | 2 | 3 | 4; // 0-少量 1-较少 2-适中 3-较多 4-大量
   note?: string;
 }
 


### PR DESCRIPTION
## Summary
- 进食量从 3 级扩展为 5 级：少量/较少/适中/较多/大量
- 类型从 `1|2|3` 改为 `0|1|2|3|4`
- 向后兼容：历史数据 1/2/3 对应新的 较少/适中/较多
- 新的饭桶图标设计，5 层横条填充

## Test plan
- [ ] 添加饮食记录，验证 5 个级别都可选
- [ ] 查看历史饮食记录，验证旧数据显示正常
- [ ] 验证图标在不同级别显示正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)