### PR TITLE
feat(stats): improve data page UX

### DIFF
--- a/src/components/RecordItem/index.css
+++ b/src/components/RecordItem/index.css
@@ -56,3 +56,12 @@
   border-radius: 16px;
   flex-shrink: 0;
 }
+
+.specimen-tag {
+  font-size: var(--font-size-sm);
+  padding: 4px 12px;
+  border-radius: 8px;
+  background-color: #e6f4ff;
+  color: #69c0ff;
+  flex-shrink: 0;
+}

--- a/src/components/RecordItem/index.tsx
+++ b/src/components/RecordItem/index.tsx
@@ -132,10 +132,12 @@ export default function RecordItem({ record, showTypeIcon = false }: RecordItemP
         );
       case "labtest": {
         const categoryText = getLabTestCategories(record.indicators);
+        const specimenText = record.specimen || "血液";
         return (
-          <Text className="record-desc">
-            {categoryText || `${record.imageFileIds.length}张图片`}
-          </Text>
+          <>
+            <Text className="specimen-tag">{specimenText}</Text>
+            {categoryText && <Text className="record-desc">{categoryText}</Text>}
+          </>
         );
       }
       case "exam": {

--- a/src/pages/labtest/add/index.css
+++ b/src/pages/labtest/add/index.css
@@ -1,6 +1,12 @@
 @import url("../../../styles/form.css");
 
 /* 标本类型选择 */
+.section-desc {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+  margin-bottom: 16px;
+}
+
 .specimen-options {
   display: flex;
   flex-wrap: wrap;

--- a/src/pages/labtest/add/index.tsx
+++ b/src/pages/labtest/add/index.tsx
@@ -327,6 +327,7 @@ export default function LabTestAdd() {
       {/* 标本类型 */}
       <View className="section">
         <Text className="section-title">标本类型</Text>
+        <Text className="section-desc">上传的化验单指标须属于同一标本类型</Text>
         <View className="specimen-options">
           {SPECIMEN_OPTIONS.map((opt) => (
             <View

--- a/src/pages/stats/components/StoolChartView.tsx
+++ b/src/pages/stats/components/StoolChartView.tsx
@@ -1,14 +1,29 @@
 import { View, Text } from "@tarojs/components";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import BarChart from "../../../components/BarChart";
+import { COLORS } from "../../../constants/colors";
 import type { ChartEvent } from "../../../types";
+
+// 排便得分颜色：好(7-10)绿、中(4-6)黄、差(0-3)红
+const getScoreColor = (score: number): string => {
+  if (score >= 7) return COLORS.primary;
+  if (score >= 4) return COLORS.yellow;
+  return COLORS.red;
+};
+
+// 排便次数颜色：好(1-2)绿、中(0或3-4)黄、差(5+)红
+const getCountColor = (count: number): string => {
+  if (count >= 1 && count <= 2) return COLORS.primary;
+  if (count >= 5) return COLORS.red;
+  return COLORS.yellow;
+};
 
 interface StoolChartViewProps {
   title: string;
   data: { date: string; value: number }[];
   maxValue?: number;
   loading: boolean;
-  showHelp?: boolean;
+  mode: "score" | "count";
   events: ChartEvent[];
   onEventTap: (event: ChartEvent) => void;
   onAddEvent: () => void;
@@ -20,13 +35,17 @@ export default function StoolChartView({
   data,
   maxValue,
   loading,
-  showHelp,
+  mode,
   events,
   onEventTap,
   onAddEvent,
   dateRangeSelector,
 }: StoolChartViewProps) {
   const [scoreHelpVisible, setScoreHelpVisible] = useState(false);
+  const getBarColor = useCallback(
+    (value: number) => (mode === "score" ? getScoreColor(value) : getCountColor(value)),
+    [mode],
+  );
 
   return (
     <View className="stats-view">
@@ -34,7 +53,7 @@ export default function StoolChartView({
         <View className="stats-header-row">
           <View className="stats-title-row">
             <Text className="stats-title">{title}</Text>
-            {showHelp && (
+            {mode === "score" && (
               <View className="stats-help-btn" onClick={() => setScoreHelpVisible(true)}>
                 <Text>?</Text>
               </View>
@@ -56,7 +75,13 @@ export default function StoolChartView({
             <Text>暂无数据</Text>
           </View>
         ) : (
-          <BarChart data={data} maxValue={maxValue} events={events} onEventTap={onEventTap} />
+          <BarChart
+            data={data}
+            maxValue={maxValue}
+            events={events}
+            onEventTap={onEventTap}
+            getBarColor={getBarColor}
+          />
         )}
       </View>
 

--- a/src/pages/stats/index.css
+++ b/src/pages/stats/index.css
@@ -234,11 +234,10 @@
 
 /* 图表容器 */
 .stats-chart-container {
-  flex: 1;
   background-color: var(--color-white);
   border-radius: 16px;
   padding: 24px;
-  min-height: 400px;
+  height: 400px;
   display: flex;
   flex-direction: column;
 }

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -350,7 +350,8 @@ export default function Stats() {
     needsRefreshRef.current = false;
 
     const { startDate, endDate } = getEffectiveDateRange();
-    loadInitial(selectedType, startDate, endDate);
+    // 原始数据加载全部，图表数据按日期范围
+    loadInitial(selectedType, "2000-01-01", formatDate());
     // Load chart data for stool, labtest, and symptom
     if (selectedType === "stool") {
       loadStatsData(startDate, endDate);
@@ -363,9 +364,9 @@ export default function Stats() {
   });
 
   const handleRefresh = useCallback(async () => {
-    const { startDate, endDate } = getEffectiveDateRange();
-    await loadInitial(selectedType, startDate, endDate);
-  }, [loadInitial, selectedType, getEffectiveDateRange]);
+    // 原始数据刷新时加载全部数据
+    await loadInitial(selectedType, "2000-01-01", formatDate());
+  }, [loadInitial, selectedType]);
 
   const handleTypeChange = (type: RecordType) => {
     if (type === selectedType) return;
@@ -382,8 +383,7 @@ export default function Stats() {
     setFeelingData([]);
     setSymptomTrendData([]);
     const { startDate, endDate } = getEffectiveDateRange();
-    loadInitial(type, startDate, endDate);
-    // Load chart data for stool, labtest, and symptom
+    // Load chart data for stool, labtest, and symptom (not records, records are loaded on demand)
     if (type === "stool") {
       loadStatsData(startDate, endDate);
     } else if (type === "labtest") {
@@ -394,13 +394,19 @@ export default function Stats() {
       if (selectedSymptom) {
         loadSymptomTrendData(startDate, endDate, selectedSymptom);
       }
+    } else {
+      // meal, medication, exam, assessment 只有原始数据 tab，加载全部数据
+      loadInitial(type, "2000-01-01", formatDate());
     }
   };
 
   const handleStoolViewTabChange = (tab: StoolViewTab) => {
     if (tab === stoolViewTab) return;
     setStoolViewTab(tab);
-    if (tab !== "records" && countData.length === 0) {
+    if (tab === "records") {
+      // 原始数据tab加载全部数据
+      loadInitial(selectedType, "2000-01-01", formatDate());
+    } else if (countData.length === 0) {
       const { startDate, endDate } = getEffectiveDateRange();
       loadStatsData(startDate, endDate);
     }
@@ -409,7 +415,10 @@ export default function Stats() {
   const handleLabtestViewTabChange = (tab: LabtestViewTab) => {
     if (tab === labtestViewTab) return;
     setLabtestViewTab(tab);
-    if (tab === "chart" && labtestChartData.length === 0) {
+    if (tab === "records") {
+      // 原始数据tab加载全部数据
+      loadInitial(selectedType, "2000-01-01", formatDate());
+    } else if (labtestChartData.length === 0) {
       const { startDate, endDate } = getEffectiveDateRange();
       loadLabtestStatsData(startDate, endDate, selectedIndicator);
     }
@@ -418,13 +427,18 @@ export default function Stats() {
   const handleSymptomViewTabChange = (tab: SymptomViewTab) => {
     if (tab === symptomViewTab) return;
     setSymptomViewTab(tab);
-    const { startDate, endDate } = getEffectiveDateRange();
-    if (tab === "feeling" && feelingData.length === 0) {
-      loadFeelingStatsData(startDate, endDate);
-    } else if (tab === "weight" && weightChartData.length === 0) {
-      loadWeightStatsData(startDate, endDate);
-    } else if (tab === "symptom" && symptomTrendData.length === 0 && selectedSymptom) {
-      loadSymptomTrendData(startDate, endDate, selectedSymptom);
+    if (tab === "records") {
+      // 原始数据tab加载全部数据
+      loadInitial(selectedType, "2000-01-01", formatDate());
+    } else {
+      const { startDate, endDate } = getEffectiveDateRange();
+      if (tab === "feeling" && feelingData.length === 0) {
+        loadFeelingStatsData(startDate, endDate);
+      } else if (tab === "weight" && weightChartData.length === 0) {
+        loadWeightStatsData(startDate, endDate);
+      } else if (tab === "symptom" && symptomTrendData.length === 0 && selectedSymptom) {
+        loadSymptomTrendData(startDate, endDate, selectedSymptom);
+      }
     }
   };
 
@@ -458,15 +472,14 @@ export default function Stats() {
       }
       setCustomStartDate(startDate);
       setCustomEndDate(endDate);
-      setRecords([]);
-      loadInitial(selectedType, startDate, endDate);
+      // 日期范围变化只影响图表，不影响原始数据
       if (selectedType === "stool" && stoolViewTab !== "records") {
         loadStatsData(startDate, endDate);
       }
       if (selectedType === "labtest" && labtestViewTab === "chart") {
         loadLabtestStatsData(startDate, endDate, selectedIndicator);
       }
-      if (selectedType === "symptom") {
+      if (selectedType === "symptom" && symptomViewTab !== "records") {
         // Clear non-active tabs so they reload when switched to
         setFeelingData([]);
         setWeightChartData([]);
@@ -493,15 +506,14 @@ export default function Stats() {
   };
 
   const handleCustomDateChange = (start: string, end: string) => {
-    setRecords([]);
-    loadInitial(selectedType, start, end);
+    // 日期范围变化只影响图表，不影响原始数据
     if (selectedType === "stool" && stoolViewTab !== "records") {
       loadStatsData(start, end);
     }
     if (selectedType === "labtest" && labtestViewTab === "chart") {
       loadLabtestStatsData(start, end, selectedIndicator);
     }
-    if (selectedType === "symptom") {
+    if (selectedType === "symptom" && symptomViewTab !== "records") {
       // Clear non-active tabs so they reload when switched to
       setFeelingData([]);
       setWeightChartData([]);
@@ -705,7 +717,7 @@ export default function Stats() {
           data={scoreData}
           maxValue={10}
           loading={statsLoading}
-          showHelp
+          mode="score"
           events={events}
           onEventTap={handleEventTap}
           onAddEvent={handleAddEvent}
@@ -716,6 +728,7 @@ export default function Stats() {
           title="每日排便次数"
           data={countData}
           loading={statsLoading}
+          mode="count"
           events={events}
           onEventTap={handleEventTap}
           onAddEvent={handleAddEvent}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -13,15 +13,10 @@ export function formatTime(date: Date = new Date()): string {
   return `${hours}:${minutes}`;
 }
 
-// 格式化显示日期 (4月10日，非今年显示年份：2025年4月10日)
+// 格式化显示日期 (2025年4月10日)
 export function formatDisplayDate(dateStr: string): string {
   const date = new Date(dateStr);
-  const currentYear = new Date().getFullYear();
-  const year = date.getFullYear();
-  if (year !== currentYear) {
-    return `${year}年${date.getMonth() + 1}月${date.getDate()}日`;
-  }
-  return `${date.getMonth() + 1}月${date.getDate()}日`;
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
 }
 
 // 获取星期几


### PR DESCRIPTION
## Summary
- Labtest: add specimen type hint and display in list with blue tag
- Stats: raw data tab loads all records, not limited by date range
- Stats: fix chart container height to 400px
- Stool charts: dynamic colors based on score/count severity
- Records list: always show year in date display

## Test plan
- [ ] Verify labtest specimen hint shows on add page
- [ ] Verify labtest list shows specimen type with blue tag
- [ ] Verify raw data tab shows all records regardless of date range
- [ ] Verify stool score/count charts show correct colors
- [ ] Verify records list always displays year

🤖 Generated with [Claude Code](https://claude.com/claude-code)