### PR TITLE
feat(stats): add exam type filter in data page

### DIFF
--- a/src/pages/stats/index.css
+++ b/src/pages/stats/index.css
@@ -117,6 +117,29 @@
   border-bottom-color: var(--color-primary);
 }
 
+/* 筛选标签 */
+.filter-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 16px 24px;
+  background-color: var(--color-white);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.filter-tab {
+  padding: 8px 16px;
+  border-radius: 16px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg);
+}
+
+.filter-tab.active {
+  background-color: var(--color-primary);
+  color: var(--color-white);
+}
+
 /* 统计视图 */
 .stats-view {
   flex: 1;

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -1,6 +1,6 @@
 import { View, Text } from "@tarojs/components";
 import Taro, { useDidShow } from "@tarojs/taro";
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { symptomService } from "../../services/symptom";
 import { mealService } from "../../services/meal";
 import { stoolService } from "../../services/stool";
@@ -15,7 +15,14 @@ import { AnyRecord } from "../../components/RecordItem";
 import CalendarPopup from "../../components/CalendarPopup";
 import EventFormPopup from "../../components/EventFormPopup";
 import { LineChartData } from "../../components/LineChart";
-import { RecordType, RECORD_TYPE_OPTIONS, LabTestRecord, ChartEvent } from "../../types";
+import {
+  RecordType,
+  RECORD_TYPE_OPTIONS,
+  LabTestRecord,
+  ExamRecord,
+  ChartEvent,
+} from "../../types";
+import { EXAM_TYPES } from "../../constants/exam";
 import StoolChartView from "./components/StoolChartView";
 import LabtestChartView from "./components/LabtestChartView";
 import WeightChartView from "./components/WeightChartView";
@@ -38,6 +45,7 @@ type StoolViewTab = "score" | "count" | "records";
 type LabtestViewTab = "chart" | "records";
 type SymptomViewTab = "feeling" | "weight" | "symptom" | "records";
 type DateRangePreset = "30" | "90" | "365" | "1095" | "all" | "custom";
+type ExamTypeFilter = "all" | (typeof EXAM_TYPES)[number]["value"];
 
 const PAGE_SIZE = 50;
 
@@ -104,6 +112,9 @@ export default function Stats() {
   // Weight stats state
   const [weightChartData, setWeightChartData] = useState<LineChartData[]>([]);
   const [weightStatsLoading, setWeightStatsLoading] = useState(false);
+
+  // Exam filter state
+  const [examTypeFilter, setExamTypeFilter] = useState<ExamTypeFilter>("all");
 
   // Feeling stats state
   const [feelingData, setFeelingData] = useState<{ date: string; value: number }[]>([]);
@@ -327,6 +338,17 @@ export default function Stats() {
   );
 
   const needsRefreshRef = useRef(true);
+
+  // 根据筛选条件过滤记录
+  const filteredRecords = useMemo(() => {
+    if (selectedType === "exam" && examTypeFilter !== "all") {
+      return records.filter(
+        (r) =>
+          r._type === "exam" && (r as ExamRecord & { _type: "exam" }).examType === examTypeFilter,
+      );
+    }
+    return records;
+  }, [records, selectedType, examTypeFilter]);
 
   useEffect(() => {
     const handleRecordChange = () => {
@@ -711,6 +733,26 @@ export default function Stats() {
         </View>
       )}
 
+      {selectedType === "exam" && (
+        <View className="filter-tabs">
+          <View
+            className={`filter-tab ${examTypeFilter === "all" ? "active" : ""}`}
+            onClick={() => setExamTypeFilter("all")}
+          >
+            <Text>全部</Text>
+          </View>
+          {EXAM_TYPES.map((type) => (
+            <View
+              key={type.value}
+              className={`filter-tab ${examTypeFilter === type.value ? "active" : ""}`}
+              onClick={() => setExamTypeFilter(type.value)}
+            >
+              <Text>{type.label}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
       {selectedType === "stool" && stoolViewTab === "score" ? (
         <StoolChartView
           title="每日排便得分"
@@ -782,7 +824,7 @@ export default function Stats() {
         />
       ) : (
         <RecordsList
-          records={records}
+          records={filteredRecords}
           loading={loading}
           loadingMore={loadingMore}
           hasMore={hasMore}

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -50,6 +50,21 @@ type DateRangePreset = "30" | "90" | "365" | "1095" | "all" | "custom";
 type ExamTypeFilter = "all" | (typeof EXAM_TYPES)[number]["value"];
 type AssessmentTypeFilter = "all" | (typeof ASSESSMENT_TYPES)[number]["value"];
 
+// 化验类别列表
+const LABTEST_CATEGORIES = [
+  "血常规",
+  "炎症指标",
+  "肝肾功能",
+  "电解质",
+  "血糖",
+  "心肌标志物",
+  "凝血功能",
+  "血脂",
+  "尿常规",
+  "便常规",
+] as const;
+type LabtestCategoryFilter = "all" | (typeof LABTEST_CATEGORIES)[number];
+
 const PAGE_SIZE = 50;
 
 const services = {
@@ -121,6 +136,9 @@ export default function Stats() {
 
   // Assessment filter state
   const [assessmentTypeFilter, setAssessmentTypeFilter] = useState<AssessmentTypeFilter>("all");
+
+  // Labtest category filter state
+  const [labtestCategoryFilter, setLabtestCategoryFilter] = useState<LabtestCategoryFilter>("all");
 
   // Feeling stats state
   const [feelingData, setFeelingData] = useState<{ date: string; value: number }[]>([]);
@@ -360,8 +378,30 @@ export default function Stats() {
           (r as AssessmentRecord & { _type: "assessment" }).type === assessmentTypeFilter,
       );
     }
+    if (
+      selectedType === "labtest" &&
+      labtestViewTab === "records" &&
+      labtestCategoryFilter !== "all"
+    ) {
+      return records.filter((r) => {
+        if (r._type !== "labtest") return false;
+        const labtestRecord = r as LabTestRecord & { _type: "labtest" };
+        // 检查是否有任何指标属于选中的类别
+        return labtestRecord.indicators.some((ind) => {
+          const matched = findStandardIndicator(ind.name, labtestRecord.specimen);
+          return matched && matched.category === labtestCategoryFilter;
+        });
+      });
+    }
     return records;
-  }, [records, selectedType, examTypeFilter, assessmentTypeFilter]);
+  }, [
+    records,
+    selectedType,
+    examTypeFilter,
+    assessmentTypeFilter,
+    labtestCategoryFilter,
+    labtestViewTab,
+  ]);
 
   useEffect(() => {
     const handleRecordChange = () => {
@@ -781,6 +821,26 @@ export default function Stats() {
               onClick={() => setAssessmentTypeFilter(type.value)}
             >
               <Text>{type.label}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {selectedType === "labtest" && labtestViewTab === "records" && (
+        <View className="filter-tabs">
+          <View
+            className={`filter-tab ${labtestCategoryFilter === "all" ? "active" : ""}`}
+            onClick={() => setLabtestCategoryFilter("all")}
+          >
+            <Text>全部</Text>
+          </View>
+          {LABTEST_CATEGORIES.map((category) => (
+            <View
+              key={category}
+              className={`filter-tab ${labtestCategoryFilter === category ? "active" : ""}`}
+              onClick={() => setLabtestCategoryFilter(category)}
+            >
+              <Text>{category}</Text>
             </View>
           ))}
         </View>

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -20,9 +20,11 @@ import {
   RECORD_TYPE_OPTIONS,
   LabTestRecord,
   ExamRecord,
+  AssessmentRecord,
   ChartEvent,
 } from "../../types";
 import { EXAM_TYPES } from "../../constants/exam";
+import { ASSESSMENT_TYPES } from "../../constants/assessment";
 import StoolChartView from "./components/StoolChartView";
 import LabtestChartView from "./components/LabtestChartView";
 import WeightChartView from "./components/WeightChartView";
@@ -46,6 +48,7 @@ type LabtestViewTab = "chart" | "records";
 type SymptomViewTab = "feeling" | "weight" | "symptom" | "records";
 type DateRangePreset = "30" | "90" | "365" | "1095" | "all" | "custom";
 type ExamTypeFilter = "all" | (typeof EXAM_TYPES)[number]["value"];
+type AssessmentTypeFilter = "all" | (typeof ASSESSMENT_TYPES)[number]["value"];
 
 const PAGE_SIZE = 50;
 
@@ -115,6 +118,9 @@ export default function Stats() {
 
   // Exam filter state
   const [examTypeFilter, setExamTypeFilter] = useState<ExamTypeFilter>("all");
+
+  // Assessment filter state
+  const [assessmentTypeFilter, setAssessmentTypeFilter] = useState<AssessmentTypeFilter>("all");
 
   // Feeling stats state
   const [feelingData, setFeelingData] = useState<{ date: string; value: number }[]>([]);
@@ -347,8 +353,15 @@ export default function Stats() {
           r._type === "exam" && (r as ExamRecord & { _type: "exam" }).examType === examTypeFilter,
       );
     }
+    if (selectedType === "assessment" && assessmentTypeFilter !== "all") {
+      return records.filter(
+        (r) =>
+          r._type === "assessment" &&
+          (r as AssessmentRecord & { _type: "assessment" }).type === assessmentTypeFilter,
+      );
+    }
     return records;
-  }, [records, selectedType, examTypeFilter]);
+  }, [records, selectedType, examTypeFilter, assessmentTypeFilter]);
 
   useEffect(() => {
     const handleRecordChange = () => {
@@ -746,6 +759,26 @@ export default function Stats() {
               key={type.value}
               className={`filter-tab ${examTypeFilter === type.value ? "active" : ""}`}
               onClick={() => setExamTypeFilter(type.value)}
+            >
+              <Text>{type.label}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {selectedType === "assessment" && (
+        <View className="filter-tabs">
+          <View
+            className={`filter-tab ${assessmentTypeFilter === "all" ? "active" : ""}`}
+            onClick={() => setAssessmentTypeFilter("all")}
+          >
+            <Text>全部</Text>
+          </View>
+          {ASSESSMENT_TYPES.map((type) => (
+            <View
+              key={type.value}
+              className={`filter-tab ${assessmentTypeFilter === type.value ? "active" : ""}`}
+              onClick={() => setAssessmentTypeFilter(type.value)}
             >
               <Text>{type.label}</Text>
             </View>

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -47,8 +47,6 @@ type StoolViewTab = "score" | "count" | "records";
 type LabtestViewTab = "chart" | "records";
 type SymptomViewTab = "feeling" | "weight" | "symptom" | "records";
 type DateRangePreset = "30" | "90" | "365" | "1095" | "all" | "custom";
-type ExamTypeFilter = "all" | (typeof EXAM_TYPES)[number]["value"];
-type AssessmentTypeFilter = "all" | (typeof ASSESSMENT_TYPES)[number]["value"];
 
 // 化验类别列表
 const LABTEST_CATEGORIES = [
@@ -63,7 +61,6 @@ const LABTEST_CATEGORIES = [
   "尿常规",
   "便常规",
 ] as const;
-type LabtestCategoryFilter = "all" | (typeof LABTEST_CATEGORIES)[number];
 
 const PAGE_SIZE = 50;
 
@@ -131,14 +128,14 @@ export default function Stats() {
   const [weightChartData, setWeightChartData] = useState<LineChartData[]>([]);
   const [weightStatsLoading, setWeightStatsLoading] = useState(false);
 
-  // Exam filter state
-  const [examTypeFilter, setExamTypeFilter] = useState<ExamTypeFilter>("all");
+  // Exam filter state (multi-select, empty = all)
+  const [examTypeFilters, setExamTypeFilters] = useState<Set<string>>(new Set());
 
-  // Assessment filter state
-  const [assessmentTypeFilter, setAssessmentTypeFilter] = useState<AssessmentTypeFilter>("all");
+  // Assessment filter state (multi-select, empty = all)
+  const [assessmentTypeFilters, setAssessmentTypeFilters] = useState<Set<string>>(new Set());
 
-  // Labtest category filter state
-  const [labtestCategoryFilter, setLabtestCategoryFilter] = useState<LabtestCategoryFilter>("all");
+  // Labtest category filter state (multi-select, empty = all)
+  const [labtestCategoryFilters, setLabtestCategoryFilters] = useState<Set<string>>(new Set());
 
   // Feeling stats state
   const [feelingData, setFeelingData] = useState<{ date: string; value: number }[]>([]);
@@ -363,25 +360,25 @@ export default function Stats() {
 
   const needsRefreshRef = useRef(true);
 
-  // 根据筛选条件过滤记录
+  // 根据筛选条件过滤记录（多选，空集合表示全部）
   const filteredRecords = useMemo(() => {
-    if (selectedType === "exam" && examTypeFilter !== "all") {
+    if (selectedType === "exam" && examTypeFilters.size > 0) {
       return records.filter(
         (r) =>
-          r._type === "exam" && (r as ExamRecord & { _type: "exam" }).examType === examTypeFilter,
+          r._type === "exam" && examTypeFilters.has((r as ExamRecord & { _type: "exam" }).examType),
       );
     }
-    if (selectedType === "assessment" && assessmentTypeFilter !== "all") {
+    if (selectedType === "assessment" && assessmentTypeFilters.size > 0) {
       return records.filter(
         (r) =>
           r._type === "assessment" &&
-          (r as AssessmentRecord & { _type: "assessment" }).type === assessmentTypeFilter,
+          assessmentTypeFilters.has((r as AssessmentRecord & { _type: "assessment" }).type),
       );
     }
     if (
       selectedType === "labtest" &&
       labtestViewTab === "records" &&
-      labtestCategoryFilter !== "all"
+      labtestCategoryFilters.size > 0
     ) {
       return records.filter((r) => {
         if (r._type !== "labtest") return false;
@@ -389,7 +386,7 @@ export default function Stats() {
         // 检查是否有任何指标属于选中的类别
         return labtestRecord.indicators.some((ind) => {
           const matched = findStandardIndicator(ind.name, labtestRecord.specimen);
-          return matched && matched.category === labtestCategoryFilter;
+          return matched && labtestCategoryFilters.has(matched.category);
         });
       });
     }
@@ -397,9 +394,9 @@ export default function Stats() {
   }, [
     records,
     selectedType,
-    examTypeFilter,
-    assessmentTypeFilter,
-    labtestCategoryFilter,
+    examTypeFilters,
+    assessmentTypeFilters,
+    labtestCategoryFilters,
     labtestViewTab,
   ]);
 
@@ -788,17 +785,21 @@ export default function Stats() {
 
       {selectedType === "exam" && (
         <View className="filter-tabs">
-          <View
-            className={`filter-tab ${examTypeFilter === "all" ? "active" : ""}`}
-            onClick={() => setExamTypeFilter("all")}
-          >
-            <Text>全部</Text>
-          </View>
           {EXAM_TYPES.map((type) => (
             <View
               key={type.value}
-              className={`filter-tab ${examTypeFilter === type.value ? "active" : ""}`}
-              onClick={() => setExamTypeFilter(type.value)}
+              className={`filter-tab ${examTypeFilters.has(type.value) ? "active" : ""}`}
+              onClick={() => {
+                setExamTypeFilters((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(type.value)) {
+                    next.delete(type.value);
+                  } else {
+                    next.add(type.value);
+                  }
+                  return next;
+                });
+              }}
             >
               <Text>{type.label}</Text>
             </View>
@@ -808,17 +809,21 @@ export default function Stats() {
 
       {selectedType === "assessment" && (
         <View className="filter-tabs">
-          <View
-            className={`filter-tab ${assessmentTypeFilter === "all" ? "active" : ""}`}
-            onClick={() => setAssessmentTypeFilter("all")}
-          >
-            <Text>全部</Text>
-          </View>
           {ASSESSMENT_TYPES.map((type) => (
             <View
               key={type.value}
-              className={`filter-tab ${assessmentTypeFilter === type.value ? "active" : ""}`}
-              onClick={() => setAssessmentTypeFilter(type.value)}
+              className={`filter-tab ${assessmentTypeFilters.has(type.value) ? "active" : ""}`}
+              onClick={() => {
+                setAssessmentTypeFilters((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(type.value)) {
+                    next.delete(type.value);
+                  } else {
+                    next.add(type.value);
+                  }
+                  return next;
+                });
+              }}
             >
               <Text>{type.label}</Text>
             </View>
@@ -828,17 +833,21 @@ export default function Stats() {
 
       {selectedType === "labtest" && labtestViewTab === "records" && (
         <View className="filter-tabs">
-          <View
-            className={`filter-tab ${labtestCategoryFilter === "all" ? "active" : ""}`}
-            onClick={() => setLabtestCategoryFilter("all")}
-          >
-            <Text>全部</Text>
-          </View>
           {LABTEST_CATEGORIES.map((category) => (
             <View
               key={category}
-              className={`filter-tab ${labtestCategoryFilter === category ? "active" : ""}`}
-              onClick={() => setLabtestCategoryFilter(category)}
+              className={`filter-tab ${labtestCategoryFilters.has(category) ? "active" : ""}`}
+              onClick={() => {
+                setLabtestCategoryFilters((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(category)) {
+                    next.delete(category);
+                  } else {
+                    next.add(category);
+                  }
+                  return next;
+                });
+              }}
             >
               <Text>{category}</Text>
             </View>


### PR DESCRIPTION
## Summary
- Add filter tabs for exam records to filter by exam type (超声/CT/MRI/肠镜/胃镜/X光/其他)

Closes #214

## Test plan
- [ ] Open stats page and select "检查" type
- [ ] Verify filter tabs appear with "全部" and all exam types
- [ ] Click different filter tabs and verify records are filtered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)