### PR TITLE
style(labtest): improve specimen hint styling

### DIFF
--- a/src/pages/labtest/add/index.css
+++ b/src/pages/labtest/add/index.css
@@ -2,9 +2,11 @@
 
 /* 标本类型选择 */
 .section-desc {
+  display: block;
   font-size: var(--font-size-sm);
-  color: var(--color-text-tertiary);
-  margin-bottom: 16px;
+  color: var(--color-orange);
+  margin-top: -16px;
+  margin-bottom: 8px;
 }
 
 .specimen-options {


### PR DESCRIPTION
## Summary
- Change specimen hint text color to orange for better visibility
- Add proper spacing with `display: block` and adjusted margins

## Test plan
- [ ] Verify hint text is orange colored
- [ ] Verify spacing between title, hint, and options looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)