### PR TITLE
style(labtest): adjust indicator value colors

### DIFF
--- a/src/pages/labtest/add/index.css
+++ b/src/pages/labtest/add/index.css
@@ -185,20 +185,20 @@
 .indicator-col-value {
   flex: 1.5;
   font-size: var(--font-size-sm);
-  color: var(--color-primary);
+  color: var(--color-text);
 }
 
-.abnormal-flag {
+.indicator-col-value .abnormal-flag {
   margin-left: 4px;
   font-size: var(--font-size-xs);
 }
 
-.abnormal-flag.high {
+.indicator-col-value .abnormal-flag.high {
   color: var(--color-red);
 }
 
-.abnormal-flag.low {
-  color: var(--color-primary);
+.indicator-col-value .abnormal-flag.low {
+  color: var(--color-orange);
 }
 
 .indicator-col-ref {


### PR DESCRIPTION
## Summary
- Use default text color for indicator values
- Use orange for low value indicator (↓)
- Use red for high value indicator (↑)

## Test plan
- [ ] Verify normal values show in default text color
- [ ] Verify low values show orange arrow
- [ ] Verify high values show red arrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)