### PR TITLE
fix(meal): prioritize frequent foods over custom foods in favorites

### DIFF
--- a/src/pages/meal/add/index.tsx
+++ b/src/pages/meal/add/index.tsx
@@ -200,8 +200,8 @@ export default function MealAdd() {
     }
   };
 
-  // 「我的常用」的食物列表：自定义食物 + 预设高频食物
-  const myFavoriteFoods = [...customFoods, ...topFoods.filter((f) => !customFoods.includes(f))];
+  // 「我的常用」的食物列表：高频食物优先，然后是未出现的自定义食物
+  const myFavoriteFoods = [...topFoods, ...customFoods.filter((f) => !topFoods.includes(f))];
 
   // 当前分类的食物列表（统一为 { name, emoji } 格式）
   const currentFoods =


### PR DESCRIPTION
## Summary
- 修改"我的常用"分类的食物排序逻辑：高频食物优先显示，然后是未出现的自定义食物

## Test plan
- [ ] 添加饮食记录，验证"常用"分类显示高频食物在前
- [ ] 添加自定义食物，验证其出现在高频食物之后

🤖 Generated with [Claude Code](https://claude.ai/code)